### PR TITLE
StreamWrite and Async RPC write to socket in background bthread.

### DIFF
--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -292,11 +292,11 @@ public:
             , pipelined_count(0), auth_flags(0)
             , ignore_eovercrowded(false) {}
     };
-    int Write(butil::IOBuf *msg, const WriteOptions* options = NULL);
+    int Write(butil::IOBuf *msg, const WriteOptions* options = NULL, bool in_background = false);
 
     // Write an user-defined message. `msg' is released when Write() is
     // successful and *may* remain unchanged otherwise.
-    int Write(SocketMessagePtr<>& msg, const WriteOptions* options = NULL);
+    int Write(SocketMessagePtr<>& msg, const WriteOptions* options = NULL, bool in_background = false);
 
     // The file descriptor
     int fd() const { return _fd.load(butil::memory_order_relaxed); }
@@ -576,7 +576,7 @@ private:
     };
 
     int ConductError(bthread_id_t);
-    int StartWrite(WriteRequest*, const WriteOptions&);
+    int StartWrite(WriteRequest*, const WriteOptions&, bool in_background = false);
 
     int Dereference();
 friend void DereferenceSocket(Socket*);

--- a/src/brpc/stream.cpp
+++ b/src/brpc/stream.cpp
@@ -290,7 +290,9 @@ int Stream::AppendIfNotFull(const butil::IOBuf &data) {
 
     size_t data_length = data.length();
     butil::IOBuf copied_data(data);
-    const int rc = _fake_socket_weak_ref->Write(&copied_data);
+    // Always write stream message in background bthread to avoid blocking current thread.
+    bool write_in_background = true;
+    const int rc = _fake_socket_weak_ref->Write(&copied_data, nullptr, write_in_background);
     if (rc != 0) {
         // Stream may be closed by peer before
         LOG(WARNING) << "Fail to write to _fake_socket, " << berror();


### PR DESCRIPTION
Add write_in_background parameter to Socket::StartWrite.
StreamWrite and async RPC create background bthread to write to socket so that current thread won't block for 10-20us writing to socket.