### PR TITLE
Redis: Support auth command

### DIFF
--- a/src/brpc/redis.cpp
+++ b/src/brpc/redis.cpp
@@ -472,6 +472,23 @@ TransactionHandler* RedisService::NewTransactionHandler() const {
     return NULL;
 }
 
+bool RedisService::RequirePass() const {
+    LOG(ERROR) << "RequirePass is not implemented";
+    return false;
+}
+
+bool RedisService::AuthenticateUser(RedisUserAuthContext* ctx,
+        const butil::StringPiece& username, const butil::StringPiece& password) const {
+    LOG(ERROR) << "AuthenticateUser is not implemented";
+    ctx->SetAuthenticated();
+    return true;
+}
+
+bool RedisService::AuthRequired(const RedisUserAuthContext* ctx, const butil::StringPiece& command) const {
+    LOG(ERROR) << "AuthRequired is not implemented";
+    return false;
+}
+
 RedisCommandHandler* RedisCommandHandler::NewTransactionHandler() {
     LOG(ERROR) << "NewTransactionHandler is not implemented";
     return NULL;


### PR DESCRIPTION
1. Introduce a class `RedisUserAuthContext` to hold authentication context. It holds a bool flag `authenticated` currently. But user-related fields may be put into it when ACL is acquired in later versions.
2. Applications need to implement RedisService::RequirePass() to check whether `requirepass` has been configured.
3. Applications need to implement RedisService::AuthenticateUser() to authenticate user.
4. Applications need to implement RedisService::AuthRequired() to check whether current command needs authentication.