### PR TITLE
export connection list

### DIFF
--- a/src/brpc/policy/redis_protocol.cpp
+++ b/src/brpc/policy/redis_protocol.cpp
@@ -66,10 +66,11 @@ struct InputResponse : public InputMessageBase {
 // This class is as parsing_context in socket.
 class RedisConnContext : public Destroyable  {
 public:
-    explicit RedisConnContext(const RedisService* rs)
+    explicit RedisConnContext(const RedisService* rs, Socket *socket)
         : redis_service(rs)
-        , batched_size(0) {
-        user_ctx.reset(rs->NewConnectionContext());
+        , user_ctx(rs->NewConnectionContext(socket))
+        , batched_size(0)
+    {
     }
 
     ~RedisConnContext();
@@ -150,7 +151,7 @@ ParseResult ParseRedisMessage(butil::IOBuf* source, Socket* socket,
         }
         RedisConnContext* ctx = static_cast<RedisConnContext*>(socket->parsing_context());
         if (ctx == NULL) {
-            ctx = new RedisConnContext(rs);
+            ctx = new RedisConnContext(rs, socket);
             socket->reset_parsing_context(ctx);
         }
         std::vector<butil::StringPiece> current_args;

--- a/src/brpc/redis.h
+++ b/src/brpc/redis.h
@@ -241,7 +241,7 @@ class RedisService {
 public:
     virtual ~RedisService() {}
 
-    virtual ConnectionContext* NewConnectionContext() const = 0;
+    virtual std::unique_ptr<ConnectionContext> NewConnectionContext(Socket *socket) const = 0;
 
     virtual RedisCommandHandlerResult DispatchCommand(ConnectionContext* ctx,
                                                       const std::vector<butil::StringPiece>& args,

--- a/src/brpc/server.cpp
+++ b/src/brpc/server.cpp
@@ -2212,6 +2212,11 @@ bool Server::AcceptRequest(Controller* cntl) const {
     return true;
 }
 
+Acceptor *Server::GetAcceptor()
+{
+    return _am;
+}
+
 #ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
 int Server::SSLSwitchCTXByHostname(struct ssl_st* ssl,
                                    int* al, Server* server) {

--- a/src/brpc/server.h
+++ b/src/brpc/server.h
@@ -576,6 +576,8 @@ public:
         return this->_has_progressive_read_method;
     }
 
+    Acceptor *GetAcceptor();
+
 private:
 friend class StatusService;
 friend class ProtobufsService;

--- a/test/brpc_redis_unittest.cpp
+++ b/test/brpc_redis_unittest.cpp
@@ -17,6 +17,7 @@
 
 
 #include <iostream>
+#include <butil/unique_ptr.h>
 #include <unordered_map>
 #include <butil/time.h>
 #include <butil/logging.h>
@@ -816,6 +817,8 @@ class MultiTransactionHandler;
 class RedisConnectionContext : public brpc::ConnectionContext
 {
 public:
+    explicit RedisConnectionContext(brpc::Socket *socket) {}
+
     // If user starts a transaction, transaction_handler indicates the
     // handler pointer that runs the transaction command.
     std::unique_ptr<MultiTransactionHandler> transaction_handler;
@@ -918,8 +921,8 @@ public:
         }
     }
 
-    brpc::ConnectionContext* NewConnectionContext() const override {
-        return new RedisConnectionContext;
+    std::unique_ptr<brpc::ConnectionContext> NewConnectionContext(brpc::Socket *socket) const override {
+        return std::unique_ptr<RedisConnectionContext>(new RedisConnectionContext(socket));
     }
 
     brpc::RedisCommandHandlerResult DispatchCommand(brpc::ConnectionContext* conn_ctx,


### PR DESCRIPTION
To implement Redis client list command, brpc should export its acceptor.