### PR TITLE
Allow a task to jump to another group for better locality.

### DIFF
--- a/src/bthread/bthread.cpp
+++ b/src/bthread/bthread.cpp
@@ -388,6 +388,15 @@ int bthread_yield(void) {
     return sched_yield();
 }
 
+int bthread_jump_group(int group_id) {
+    bthread::TaskGroup* g = bthread::tls_task_group;
+    if (NULL != g && !g->is_current_pthread_task() && group_id != g->group_id_) {
+        bthread::TaskGroup::jump_group(&g, group_id);
+        return 0;
+    }
+    return -1;
+}
+
 int bthread_set_worker_startfn(void (*start_fn)()) {
     if (start_fn == NULL) {
         return EINVAL;

--- a/src/bthread/bthread.cpp
+++ b/src/bthread/bthread.cpp
@@ -397,6 +397,15 @@ int bthread_jump_group(int group_id) {
     return -1;
 }
 
+int bthread_block(void) {
+    bthread::TaskGroup* g = bthread::tls_task_group;
+    if (NULL != g && !g->is_current_pthread_task()) {
+        bthread::TaskGroup::block(&g);
+        return 0;
+    }
+    return -1;
+}
+
 int bthread_set_worker_startfn(void (*start_fn)()) {
     if (start_fn == NULL) {
         return EINVAL;

--- a/src/bthread/bthread.h
+++ b/src/bthread/bthread.h
@@ -155,6 +155,9 @@ extern int bthread_setconcurrency(int num);
 // even if bthread_yield() is called, suspended threads may still starve.
 extern int bthread_yield(void);
 
+// Yield processor to another bthread and move current task to another group.
+extern int bthread_jump_group(int group_id);
+
 // Suspend current thread for at least `microseconds'
 // Interruptible by bthread_interrupt().
 extern int bthread_usleep(uint64_t microseconds);

--- a/src/bthread/bthread.h
+++ b/src/bthread/bthread.h
@@ -158,6 +158,9 @@ extern int bthread_yield(void);
 // Yield processor to another bthread and move current task to another group.
 extern int bthread_jump_group(int group_id);
 
+// Yield processor to another bthread and block current task.
+extern int bthread_block(void);
+
 // Suspend current thread for at least `microseconds'
 // Interruptible by bthread_interrupt().
 extern int bthread_usleep(uint64_t microseconds);

--- a/src/bthread/butex.cpp
+++ b/src/bthread/butex.cpp
@@ -319,6 +319,8 @@ int butex_wake(void* arg, bool nosignal) {
                                         : get_task_group(bbw->control, nosignal);
     if (g == tls_task_group) {
         run_in_local_task_group(g, bbw->tid, nosignal);
+    } else if (g == m->bound_task_group) {
+        g->ready_to_run_bound(bbw->tid, nosignal);
     } else {
         g->ready_to_run_remote(bbw->tid, nosignal);
     }

--- a/src/bthread/remote_task_queue.h
+++ b/src/bthread/remote_task_queue.h
@@ -49,15 +49,6 @@ public:
       } else {
         return false;
       }
-      if (tmp_cnt > 0 &&
-          _task_cnt.compare_exchange_strong(tmp_cnt, tmp_cnt - 1)) {
-        if (_tasks.try_dequeue(*task)) {
-          return true;
-        } else {
-          _task_cnt++;
-          return false;
-        }
-      }
     }
 
     bool push(bthread_t task) {

--- a/src/bthread/task_control.cpp
+++ b/src/bthread/task_control.cpp
@@ -254,6 +254,17 @@ TaskGroup* TaskControl::choose_one_group() {
     return NULL;
 }
 
+TaskGroup* TaskControl::select_group(int group_id) {
+    const size_t ngroup = _ngroup.load(butil::memory_order_acquire);
+    for (size_t i = 0; i < ngroup; i++) {
+        if (_groups[i]->group_id_ == group_id) {
+            return _groups[i];
+        }
+    }
+    LOG(ERROR) << "Selected group: " << group_id << " out of range, group number: " << ngroup;
+    return NULL;
+}
+
 extern int stop_and_join_epoll_threads();
 
 void TaskControl::stop_and_join() {

--- a/src/bthread/task_control.h
+++ b/src/bthread/task_control.h
@@ -78,6 +78,9 @@ public:
     // If this method is called after init(), it never returns NULL.
     TaskGroup* choose_one_group();
 
+    // Select task group.
+    TaskGroup* select_group(int group_id);
+
 private:
     // Add/Remove a TaskGroup.
     // Returns 0 on success, -1 otherwise.

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -819,7 +819,7 @@ void TaskGroup::ready_to_run_in_worker(void* args_in) {
 }
 
 void TaskGroup::ready_to_run_in_target_worker(void* args_in) {
-    ReadyToRunArgs* args = static_cast<ReadyToRunArgs*>(args_in);
+    ReadyToRunArgs* args = static_cast<ReadyToRunTargetArgs*>(args_in);
     if (args->target_group != nullptr) {
         return args->target_group->ready_to_run_bound(args->tid, args->nosignal);
     }
@@ -1002,7 +1002,7 @@ void TaskGroup::jump_group(TaskGroup **pg, int target_gid) {
     TaskGroup* g = *pg;
     TaskControl *c = g->control();
     TaskGroup *target_group = c->select_group(target_gid);
-    ReadyToRunArgs args = { g->current_tid(), false, target_group };
+    ReadyToRunTargetArgs args = { g->current_tid(), false, target_group };
     g->set_remained(ready_to_run_in_target_worker, &args);
     sched(pg);
 }

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -629,6 +629,12 @@ void TaskGroup::sched(TaskGroup** pg) {
               // Jump to main task if there's no task to run.
               g->_processed_tasks = 0;
               next_tid = g->_main_tid;
+            } else if (next_tid == g->current_tid()) {
+                if (!g->steal_task(&next_tid)) {
+                    next_tid = g->_main_tid;
+                    g->_processed_tasks = 0;
+                }
+                g->ready_to_run_bound(g->current_tid());
             }
         }
     }

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -819,7 +819,7 @@ void TaskGroup::ready_to_run_in_worker(void* args_in) {
 }
 
 void TaskGroup::ready_to_run_in_target_worker(void* args_in) {
-    ReadyToRunArgs* args = static_cast<ReadyToRunTargetArgs*>(args_in);
+    ReadyToRunTargetArgs* args = static_cast<ReadyToRunTargetArgs*>(args_in);
     if (args->target_group != nullptr) {
         return args->target_group->ready_to_run_bound(args->tid, args->nosignal);
     }

--- a/src/bthread/task_group.h
+++ b/src/bthread/task_group.h
@@ -109,6 +109,9 @@ public:
     // Suspend caller and move it to another group.
     static void jump_group(TaskGroup** pg, int target_gid);
 
+    // Suspend caller bthread and block it.
+    static void block(TaskGroup** pg);
+
     // Suspend caller until bthread `tid' terminates.
     static int join(bthread_t tid, void** return_value);
 
@@ -165,6 +168,9 @@ public:
 
     // Push a bthread into the bound queue from another thread.
     void ready_to_run_bound(bthread_t tid, bool nosignal = false);
+
+    // Push a bthread bound to this group back.
+    void resume_bound_task(bthread_t tid, bool nosignal = false);
 
     // Automatically decide the caller is remote or local, and call
     // the corresponding function.
@@ -224,6 +230,7 @@ public:
     };
     static void ready_to_run_in_target_worker(void*);
     static void ready_to_run_in_worker_ignoresignal(void*);
+    static void empty_callback(void*);
 
     // Wait for a task to run.
     // Returns true on success, false is treated as permanent error and the
@@ -231,7 +238,7 @@ public:
     bool wait_task(bthread_t* tid);
 
     bool steal_task(bthread_t* tid) {
-        if (_remote_rq.pop(tid) || _bound_rq.pop(tid)) {
+        if (_bound_rq.pop(tid) || _remote_rq.pop(tid)) {
             return true;
         }
 #ifndef BTHREAD_DONT_SAVE_PARKING_STATE

--- a/src/bthread/task_group.h
+++ b/src/bthread/task_group.h
@@ -214,10 +214,14 @@ public:
     struct ReadyToRunArgs {
         bthread_t tid;
         bool nosignal;
-        // the target group to push the task into, ready_to_run_in_target_worker
-        TaskGroup *target_group{};
     };
     static void ready_to_run_in_worker(void*);
+    struct ReadyToRunTargetArgs {
+        bthread_t tid;
+        bool nosignal;
+        // the target group to push the task into, ready_to_run_in_target_worker
+        TaskGroup *target_group;
+    };
     static void ready_to_run_in_target_worker(void*);
     static void ready_to_run_in_worker_ignoresignal(void*);
 

--- a/src/bthread/task_meta.h
+++ b/src/bthread/task_meta.h
@@ -93,7 +93,7 @@ struct TaskMeta {
     LocalStorage local_storage;
 
     // If this task needs to be executed on a specific task group.
-    TaskGroup *bound_task_group;
+    TaskGroup *bound_task_group{};
 
   public:
     // Only initialize [Not Reset] fields, other fields will be reset in
@@ -126,6 +126,10 @@ struct TaskMeta {
 
     StackType stack_type() const {
         return static_cast<StackType>(attr.stack_type);
+    }
+
+    void SetBoundGroup(TaskGroup* group) {
+        bound_task_group = group;
     }
 };
 


### PR DESCRIPTION
* Implement `bthread_jump_group` function allowing a bthread to jump to another group;
* Add a concurrent `bound_rq` to TaskGroup to store the tasks that are bound to the group and can only be processed by it.
* Implement `bthread_block` and `resume_bound_task` allowing a bthread to block and resume without using mutex and condition variable.

Related PR:
https://github.com/monographdb/monograph_redis/pull/379