### PR TITLE
brpc module framework.

### DIFF
--- a/src/brpc/policy/redis_protocol.cpp
+++ b/src/brpc/policy/redis_protocol.cpp
@@ -43,6 +43,8 @@ namespace bthread {
 extern BAIDU_THREAD_LOCAL TaskGroup *tls_task_group;
 }
 
+DECLARE_bool(brpc_worker_as_ext_processor);
+
 namespace brpc {
 
 DECLARE_bool(enable_rpcz);
@@ -165,10 +167,7 @@ ParseResult ParseRedisMessage(butil::IOBuf* source, Socket* socket,
         // might jump to another task group in `ConsumeCommand`.
         bthread::TaskGroup *cur_group = bthread::tls_task_group;
         bthread::TaskMeta *cur_task = cur_group->current_task();
-        if (cur_group->tx_processor_exec_ == nullptr) {
-            cur_group->TrySetExtTxProcFuncs();
-        }
-        if (cur_group->tx_processor_exec_ != nullptr) {
+        if (FLAGS_brpc_worker_as_ext_processor) {
             cur_task->SetBoundGroup(cur_group);
         }
 #ifdef IO_URING_ENABLED

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -56,6 +56,7 @@
 #include "bthread/task_group.h"
 #ifdef IO_URING_ENABLED
 #include <liburing.h>
+#include "bthread/inbound_ring_buf.h"
 #endif
 
 DEFINE_bool(dispatch_lazily, false, "dispatcher lazily creates task");

--- a/src/bthread/brpc_module.cpp
+++ b/src/bthread/brpc_module.cpp
@@ -17,24 +17,13 @@
  * under the License.
  */
 
-#ifndef BRPC_MODULE_H
-#define BRPC_MODULE_H
+#include "brpc_module.h"
+#include "bthread/bthread.h"
 
 namespace bthread {
 
-class BrpcModule {
-public:
-    virtual ~BrpcModule() {};
-
-    virtual void ExtThdStart(int thd_id) = 0;
-    virtual void ExtThdEnd(int thd_id) = 0;
-    virtual void Process(int thd_id) = 0;
-    virtual bool HasTask(int thd_id) const = 0;
-
-private:
-    static bool NotifyWorker(int thd_id);
-};
+bool BrpcModule::NotifyWorker(int thd_id) {
+  return bthread_notify_worker(thd_id);
+}
 
 }  // namespace bthread
-
-#endif //BRPC_MODULE_H

--- a/src/bthread/brpc_module.h
+++ b/src/bthread/brpc_module.h
@@ -20,18 +20,17 @@
 #ifndef BRPC_MODULE_H
 #define BRPC_MODULE_H
 
-namespace bthread {
+namespace eloq {
 
-class BrpcModule {
+class EloqModule {
 public:
-    virtual ~BrpcModule() {};
+    virtual ~EloqModule() {};
 
     virtual void ExtThdStart(int thd_id) = 0;
     virtual void ExtThdEnd(int thd_id) = 0;
     virtual void Process(int thd_id) = 0;
     virtual bool HasTask(int thd_id) const = 0;
 
-private:
     static bool NotifyWorker(int thd_id);
 };
 

--- a/src/bthread/bthread.cpp
+++ b/src/bthread/bthread.cpp
@@ -472,7 +472,7 @@ int bthread_notify_worker(int group_id) {
     if (c == nullptr) {
         return 0;
     }
-    LOG(INFO) << "notify group: " << group_id;
+    // LOG(INFO) << "notify group: " << group_id;
     return c->signal_group(group_id);
 }
 

--- a/src/bthread/bthread.cpp
+++ b/src/bthread/bthread.cpp
@@ -51,6 +51,22 @@ int bthread_set_ext_tx_prc_func(
     return -1;
 }
 
+extern std::array<bthread::BrpcModule *, 10> registered_modules;
+extern std::atomic<int> registered_module_cnt;
+
+int bthread_register_module(bthread::BrpcModule *module) {
+    static std::mutex module_mutex;
+    std::unique_lock<std::mutex> lk(module_mutex);
+    size_t i = 0;
+    while (i < registered_modules.size() && registered_modules[i] != nullptr) {
+        i++;
+    }
+    registered_modules[i] = module;
+    registered_module_cnt.fetch_add(1, std::memory_order_release);
+    return 0;
+}
+
+
 namespace bthread {
 
 DEFINE_int32(bthread_concurrency, 8 + BTHREAD_EPOLL_THREAD_NUM,

--- a/src/bthread/bthread.cpp
+++ b/src/bthread/bthread.cpp
@@ -65,8 +65,6 @@ int register_module(eloq::EloqModule *module) {
     }
     registered_modules[i] = module;
     registered_module_cnt.fetch_add(1, std::memory_order_release);
-    LOG(INFO) << "register module, module: " << module
-    << " registered_module_cnt: " << registered_module_cnt.load();
     return 0;
 }
 
@@ -472,7 +470,6 @@ int bthread_notify_worker(int group_id) {
     if (c == nullptr) {
         return 0;
     }
-    // LOG(INFO) << "notify group: " << group_id;
     return c->signal_group(group_id);
 }
 

--- a/src/bthread/bthread.h
+++ b/src/bthread/bthread.h
@@ -27,6 +27,7 @@
 #include <sys/socket.h>
 #include "bthread/types.h"
 #include "bthread/errno.h"
+#include "bthread/brpc_module.h"
 
 #if defined(__cplusplus)
 #  include <iostream>
@@ -42,6 +43,8 @@ extern int bthread_set_ext_tx_prc_func(
                 std::function<void(int16_t)>,
                 std::function<bool(bool)>,
                 std::function<bool()>>(int16_t)>);
+
+extern int bthread_register_module(bthread::BrpcModule *module);
 
 // Create bthread `fn(args)' with attributes `attr' and put the identifier into
 // `tid'. Switch to the new thread and schedule old thread to run. Use this

--- a/src/bthread/bthread.h
+++ b/src/bthread/bthread.h
@@ -44,7 +44,7 @@ extern int bthread_set_ext_tx_prc_func(
                 std::function<bool(bool)>,
                 std::function<bool()>>(int16_t)>);
 
-extern int bthread_register_module(bthread::BrpcModule *module);
+extern int register_module(eloq::EloqModule *module);
 
 // Create bthread `fn(args)' with attributes `attr' and put the identifier into
 // `tid'. Switch to the new thread and schedule old thread to run. Use this

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -353,7 +353,7 @@ void RingListener::PollAndNotify() {
     }
     cqe_ready_.store(true, std::memory_order_relaxed);
     poll_status_.store(PollStatus::Sleep, std::memory_order_relaxed);
-    LOG(INFO) << "RingModule notify worker: " << task_group_->group_id_;
+    // LOG(INFO) << "RingModule notify worker: " << task_group_->group_id_;
     RingModule::NotifyWorker(task_group_->group_id_);
 }
 

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -1,0 +1,726 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifdef IO_URING_ENABLED
+#include "brpc/socket.h"
+// #include "bthread/task_control.h"
+#include "bthread/task_group.h"
+#include "bthread/brpc_module.h"
+#include "bthread/inbound_ring_buf.h"
+#include "bthread/ring_write_buf_pool.h"
+#include "butil/threading/platform_thread.h"
+
+#include "ring_listener.h"
+
+// namespace bthread {
+//     extern TaskControl *get_task_control();
+// }
+
+RingListener::~RingListener() {
+    for (auto [fd, fd_idx]: reg_fds_) {
+        SubmitCancel(fd);
+    }
+    SubmitAll();
+
+    poll_status_.store(PollStatus::Closed, std::memory_order_release); {
+        std::unique_lock<std::mutex> lk(mux_);
+        cv_.notify_one();
+    }
+
+    if (poll_thd_.joinable()) {
+        poll_thd_.join();
+    }
+    Close();
+}
+
+int RingListener::Init() {
+    int ret = io_uring_queue_init(1024, &ring_, IORING_SETUP_SINGLE_ISSUER);
+
+    if (ret < 0) {
+        LOG(WARNING) << "Failed to initialize the IO uring of the inbound "
+                  "listener, errno: "
+               << ret;
+        Close();
+        return ret;
+    }
+    ring_init_ = true;
+
+    ret = io_uring_register_files_sparse(&ring_, 1024);
+    if (ret < 0) {
+        LOG(WARNING) << "Failed to register sparse files for the inbound listener.";
+        Close();
+        return ret;
+    }
+
+    free_reg_fd_idx_.reserve(1024);
+    for (uint16_t f_idx = 0; f_idx < 1024; ++f_idx) {
+        free_reg_fd_idx_.emplace_back(f_idx);
+    }
+
+    in_buf_ =
+            (char *) std::aligned_alloc(buf_length, buf_length * buf_ring_size);
+    in_buf_ring_ = io_uring_setup_buf_ring(&ring_, buf_ring_size, 0, 0, &ret);
+    if (in_buf_ring_ == nullptr) {
+        LOG(WARNING) << "Failed to register buffer ring for the inbound listener.";
+        Close();
+        return -1;
+    }
+
+    char *ptr = in_buf_;
+    // inbound_ring_size must be the power of 2.
+    int br_mask = buf_ring_size - 1;
+    for (size_t idx = 0; idx < buf_ring_size; idx++) {
+        io_uring_buf_ring_add(in_buf_ring_, ptr, buf_length, idx, br_mask, idx);
+        ptr += buf_length;
+    }
+    io_uring_buf_ring_advance(in_buf_ring_, buf_ring_size);
+
+    write_buf_pool_ = std::make_unique<RingWriteBufferPool>(1024, &ring_);
+
+    // ring_module_ = bthread::get_task_control()->get_ring_module();
+
+    poll_status_.store(PollStatus::Sleep, std::memory_order_release);
+    poll_thd_ = std::thread([&]() {
+        std::string ring_listener = "ring_listener:";
+        ring_listener.append(std::to_string(task_group_->group_id_));
+        butil::PlatformThread::SetName(ring_listener.c_str());
+
+        Run();
+    });
+
+    return 0;
+}
+
+int RingListener::Register(brpc::Socket *sock) {
+    int fd = sock->fd();
+    CHECK(fd>=0);
+
+    auto it = reg_fds_.find(fd);
+    if (it != reg_fds_.end()) {
+        LOG(WARNING) << "Socket " << sock->id() << ", fd: " << sock->fd()
+               << " has been registered before.";
+        return -1;
+    }
+
+    sock->reg_fd_idx_ = -1;
+    int ret = -1;
+
+    if (free_reg_fd_idx_.empty()) {
+        // All registered file slots have been taken. Cannot register the socket's
+        // fd.
+        reg_fds_.try_emplace(fd, -1);
+        ret = SubmitRecv(sock);
+    } else {
+        uint16_t fd_idx = free_reg_fd_idx_.back();
+        free_reg_fd_idx_.pop_back();
+        reg_fds_.try_emplace(fd, fd_idx);
+        sock->reg_fd_ = fd;
+        sock->reg_fd_idx_ = fd_idx;
+        ret = SubmitRegisterFile(sock, &sock->reg_fd_, fd_idx);
+    }
+
+    if (ret < 0) {
+        reg_fds_.erase(fd);
+        return -1;
+    }
+
+    return 0;
+}
+
+int RingListener::SubmitRecv(brpc::Socket *sock) {
+    io_uring_sqe *sqe = io_uring_get_sqe(&ring_);
+    if (sqe == nullptr) {
+        LOG(ERROR) << "IO uring submission queue is full for the inbound "
+                "listener, group: "
+             << task_group_->group_id_;
+        return -1;
+    }
+    int fd_idx = sock->reg_fd_idx_;
+    int sfd = fd_idx >= 0 ? fd_idx : sock->fd();
+    io_uring_prep_recv_multishot(sqe, sfd, NULL, 0, 0);
+    uint64_t data = reinterpret_cast<uint64_t>(sock);
+    data = data << 16;
+    data |= OpCodeToInt(OpCode::Recv);
+    io_uring_sqe_set_data64(sqe, data);
+
+    sqe->buf_group = 0;
+    sqe->flags |= IOSQE_BUFFER_SELECT;
+    if (fd_idx >= 0) {
+        sqe->flags |= IOSQE_FIXED_FILE;
+    }
+    // sqe->ioprio |= IORING_RECVSEND_BUNDLE;
+
+    ++submit_cnt_;
+    return 0;
+}
+
+int RingListener::SubmitFixedWrite(brpc::Socket *sock, uint16_t ring_buf_idx) {
+    io_uring_sqe *sqe = io_uring_get_sqe(&ring_);
+    if (sqe == nullptr) {
+        LOG(ERROR)
+            << "IO uring submission queue is full for the ring listener, group: "
+            << task_group_->group_id_;
+        return -1;
+    }
+
+    int fd_idx = -1;
+    // Use registered index if this socket is bound to this group and ring.
+    if (bthread::tls_task_group == sock->bound_g_) {
+        fd_idx = sock->reg_fd_idx_;
+    }
+    int sfd = fd_idx >= 0 ? fd_idx : sock->fd();
+    // LOG(INFO) << "SubmitFixedWrite tls_task_group: " << bthread::tls_task_group
+    //     << ", socket bound task_group: " << sock->bound_g_
+    //     << ", sfd: " << sfd << ", fd_idx: " << fd_idx
+    //     << ", socket: " << *sock;
+
+    const char *write_buf = write_buf_pool_->GetBuf(ring_buf_idx);
+    sock->write_buf_idx_ = ring_buf_idx;
+
+    io_uring_prep_write_fixed(sqe, sfd, write_buf, sock->write_len_, 0,
+                              ring_buf_idx);
+
+    uint64_t data = reinterpret_cast<uint64_t>(sock);
+    data = data << 16;
+    data |= OpCodeToInt(OpCode::FixedWrite);
+    io_uring_sqe_set_data64(sqe, data);
+    if (fd_idx >= 0) {
+        sqe->flags |= IOSQE_FIXED_FILE;
+    }
+
+    ++submit_cnt_;
+    return 0;
+}
+
+int RingListener::SubmitNonFixedWrite(brpc::Socket *sock) {
+    io_uring_sqe *sqe = io_uring_get_sqe(&ring_);
+    if (sqe == nullptr) {
+        LOG(ERROR)
+          << "IO uring submission queue is full for the ring listener, group: "
+          << task_group_->group_id_;
+        return -1;
+    }
+
+    int fd_idx = -1;
+    // Use registered index if this socket is bound to this group and ring.
+    if (bthread::tls_task_group == sock->bound_g_) {
+        fd_idx = sock->reg_fd_idx_;
+    }
+    int sfd = fd_idx >= 0 ? fd_idx : sock->fd();
+    // LOG(INFO) << "SubmitNonFixedWrite tls_task_group: " << bthread::tls_task_group
+    //     << ", socket bound task_group: " << sock->bound_g_
+    //     << ", sfd: " << sfd << ", fd_idx: " << fd_idx
+    //     << ", socket: " << *sock;
+
+    CHECK(sock->iovecs_.size() <= IOV_MAX);
+    io_uring_prep_writev(sqe, sfd, sock->iovecs_.data(), sock->iovecs_.size(),
+                         0);
+
+    uint64_t size = 0;
+    std::string total_data;
+    for (auto &iovec: sock->iovecs_) {
+        size += iovec.iov_len;
+        total_data.append(static_cast<char *>(iovec.iov_base), iovec.iov_len);
+    }
+    // LOG(INFO) << "SubmitNonFixedWrite() sock->iovecs size: " << sock->iovecs_.size()
+    //     << " data total size: " << size
+    //     << " socket: " << *sock << ", fd_idx: " << fd_idx
+    //     << " total data: " << total_data;
+
+    uint64_t data = reinterpret_cast<uint64_t>(sock);
+    data = data << 16;
+    data |= OpCodeToInt(OpCode::NonFixedWrite);
+    io_uring_sqe_set_data64(sqe, data);
+
+    if (fd_idx >= 0) {
+        sqe->flags |= IOSQE_FIXED_FILE;
+    }
+
+    ++submit_cnt_;
+    return 0;
+}
+
+int RingListener::SubmitWaitingNonFixedWrite(brpc::Socket *sock) {
+    io_uring_sqe *sqe = io_uring_get_sqe(&ring_);
+    if (sqe == nullptr) {
+        LOG(ERROR)
+              << "IO uring submission queue is full for the ring listener, group: "
+              << task_group_->group_id_;
+        uint64_t data = 0;
+        data |= OpCodeToInt(OpCode::WaitingNonFixedWrite);
+        if (SubmitBacklog(sock, data)) {
+            return 0;
+        }
+        return -1;
+    }
+
+    int fd_idx = -1;
+    // Use registered index if this socket is bound to this group and ring.
+    if (bthread::tls_task_group == sock->bound_g_) {
+        fd_idx = sock->reg_fd_idx_;
+    }
+    int sfd = fd_idx >= 0 ? fd_idx : sock->fd();
+    // LOG(INFO) << "SubmitWaitingNonFixedWrite tls_task_group: " << bthread::tls_task_group
+    //     << ", socket bound task_group: " << sock->bound_g_
+    //     << ", sfd: " << sfd << ", fd_idx: " << fd_idx
+    //     << ", socket: " << *sock;
+
+    CHECK(sock->iovecs_.size() <= IOV_MAX);
+
+    io_uring_prep_writev(sqe, sfd, sock->iovecs_.data(), sock->iovecs_.size(),
+                         0);
+    uint64_t size = 0;
+    std::string total_data;
+    for (auto &iovec: sock->iovecs_) {
+        size += iovec.iov_len;
+        total_data.append(static_cast<char *>(iovec.iov_base), iovec.iov_len);
+    }
+    // LOG(INFO) << "SubmitWaitingNonFixedWrite() sock->iovecs size: " << sock->iovecs_.size()
+    //     << " data total size: " << size
+    //     << " socket: " << *sock << ", fd_idx: " << fd_idx
+    //     << " total data: " << total_data;
+
+    uint64_t data = reinterpret_cast<uint64_t>(sock);
+    data = data << 16;
+    data |= OpCodeToInt(OpCode::WaitingNonFixedWrite);
+    io_uring_sqe_set_data64(sqe, data);
+
+    if (fd_idx >= 0) {
+        sqe->flags |= IOSQE_FIXED_FILE;
+    }
+
+    ++submit_cnt_;
+    return 0;
+}
+
+int RingListener::SubmitFsync(RingFsyncData *args) {
+    io_uring_sqe *sqe = io_uring_get_sqe(&ring_);
+    if (sqe == nullptr) {
+        LOG(ERROR)
+          << "IO uring submission queue is full for the ring listener, group: "
+          << task_group_->group_id_;
+        return -1;
+    }
+
+    io_uring_prep_fsync(sqe, args->fd_, 0);
+    uint64_t data = reinterpret_cast<uint64_t>(args);
+    data = data << 16;
+    data |= OpCodeToInt(OpCode::Fsync);
+    io_uring_sqe_set_data64(sqe, data);
+    ++submit_cnt_;
+    return 0;
+}
+
+int RingListener::SubmitAll() {
+    if (submit_cnt_ == 0) {
+        return 0;
+    }
+
+    int ret = io_uring_submit(&ring_);
+    if (ret >= 0) {
+        submit_cnt_ = submit_cnt_ >= ret ? submit_cnt_ - ret : 0;
+    } else {
+        // IO uring submission failed. Clears the submission count.
+        submit_cnt_ = 0;
+        LOG(ERROR) << "Failed to flush the IO uring submission queue for the "
+                "inbound listener.";
+    }
+    return ret;
+}
+
+void RingListener::PollAndNotify() {
+    io_uring_cqe *cqe = nullptr;
+    int ret = io_uring_wait_cqe(&ring_, &cqe);
+    if (ret < 0) {
+        LOG(ERROR) << "Listener uring wait errno: " << ret;
+        return;
+    }
+    cqe_ready_.store(true, std::memory_order_relaxed);
+    poll_status_.store(PollStatus::Sleep, std::memory_order_relaxed);
+    LOG(INFO) << "RingModule notify worker: " << task_group_->group_id_;
+    RingModule::NotifyWorker(task_group_->group_id_);
+}
+
+
+size_t RingListener::ExtPoll() {
+    // LOG(INFO) << "RingListener::ExtPoll, group: " << task_group_->group_id_;
+    if (!has_external_.load(std::memory_order_relaxed)) {
+        has_external_.store(true, std::memory_order_release);
+    }
+
+    // has_external_ should be updated before poll_status_ is checked.
+    std::atomic_thread_fence(std::memory_order_release);
+
+    PollStatus status = PollStatus::Sleep;
+    if (!poll_status_.compare_exchange_strong(status, PollStatus::ExtPoll)) {
+        return 0;
+    }
+
+    HandleBacklog();
+
+    io_uring_cqe *cqe = nullptr;
+    int ret = io_uring_peek_cqe(&ring_, &cqe);
+    if (ret != 0) {
+        poll_status_.store(PollStatus::Sleep, std::memory_order_relaxed);
+        return 0;
+    }
+
+    int processed = 0;
+    unsigned int head;
+    io_uring_for_each_cqe(&ring_, head, cqe) {
+        HandleCqe(cqe);
+        ++processed;
+    }
+
+    cqe_ready_.store(false, std::memory_order_relaxed);
+
+    if (processed > 0) {
+        io_uring_cq_advance(&ring_, processed);
+    }
+    cqe_ready_.store(false, std::memory_order_relaxed);
+    poll_status_.store(PollStatus::Sleep, std::memory_order_relaxed);
+
+    return processed;
+}
+
+void RingListener::ExtWakeup() {
+    has_external_.store(false, std::memory_order_relaxed);
+    if (poll_status_.load(std::memory_order_relaxed) != PollStatus::Sleep) {
+        return;
+    }
+    std::unique_lock<std::mutex> lk(mux_);
+    cv_.notify_one();
+}
+
+void RingListener::Run() {
+    while (poll_status_.load(std::memory_order_relaxed) != PollStatus::Closed) {
+        bool success = false;
+        if (!has_external_.load(std::memory_order_relaxed)) {
+            PollStatus status = PollStatus::Sleep;
+            success = poll_status_.compare_exchange_strong(status, PollStatus::Active,
+                                                           std::memory_order_acq_rel);
+            if (success) {
+                PollAndNotify();
+            }
+        }
+        std::unique_lock<std::mutex> lk(mux_);
+        cv_.wait(lk, [this]() {
+            // wait for the worker to process the ready cqes and notify RingListener when it sleeps
+            return !has_external_.load(std::memory_order_relaxed)
+                   && !cqe_ready_.load(std::memory_order_relaxed) ||
+                   poll_status_.load(std::memory_order_relaxed) ==
+                   PollStatus::Closed;
+        });
+    }
+    // while (poll_status_.load(std::memory_order_relaxed) != PollStatus::Closed) {
+    //     if (reg_cnt_.load(std::memory_order_acquire) > 0 &&
+    //         !has_external_.load(std::memory_order_relaxed)) {
+    //         PollStatus status = PollStatus::Sleep;
+    //         if (poll_status_.compare_exchange_strong(status, PollStatus::Active,
+    //                                                  std::memory_order_acq_rel)) {
+    //             PollAndNotify();
+    //         }
+    //     }
+    //     poll_status_.store(PollStatus::Sleep, std::memory_order_acq_rel);
+    //     std::unique_lock<std::mutex> lk(mux_);
+    //     cv_.wait(lk, [this]() {
+    //         return (reg_cnt_.load(std::memory_order_acquire) > 0 &&
+    //                 !has_external_.load(std::memory_order_relaxed)) ||
+    //                poll_status_.load(std::memory_order_relaxed) ==
+    //                PollStatus::Closed;
+    //     });
+    // }
+}
+
+void RingListener::RecycleReadBuf(uint16_t bid, size_t bytes) {
+    // The socket has finished processing inbound messages. Returns the borrowed
+    // buffers to the buffer ring.
+    int br_mask = buf_ring_size - 1;
+    int buf_cnt = 0;
+    while (bytes > 0) {
+        char *this_buf = in_buf_ + bid * buf_length;
+        io_uring_buf_ring_add(in_buf_ring_, this_buf, buf_length, bid, br_mask,
+                              buf_cnt);
+
+        bytes = bytes > buf_length ? bytes - buf_length : 0;
+        bid = (bid + 1) & br_mask;
+        buf_cnt++;
+    }
+    io_uring_buf_ring_advance(in_buf_ring_, buf_cnt);
+}
+
+int RingListener::SubmitCancel(int fd) {
+    io_uring_sqe *sqe = io_uring_get_sqe(&ring_);
+    if (sqe == nullptr) {
+        LOG(ERROR) << "IO uring submission queue is full for the inbound "
+                "listener, group: "
+             << task_group_->group_id_;
+        return -1;
+    }
+
+    auto it = reg_fds_.find(fd);
+    if (it == reg_fds_.end()) {
+        return 0;
+    }
+
+    int fd_idx = it->second;
+    int sfd;
+    uint64_t data;
+
+    int flags = 0;
+    if (fd_idx >= 0) {
+        flags |= IORING_ASYNC_CANCEL_FD_FIXED;
+        sfd = fd_idx;
+        data = fd_idx << 16;
+    } else {
+        sfd = fd;
+        data = UINT16_MAX << 16;
+    }
+
+    io_uring_prep_cancel_fd(sqe, sfd, flags);
+    data |= OpCodeToInt(OpCode::CancelRecv);
+    io_uring_sqe_set_data64(sqe, data);
+    if (fd_idx >= 0) {
+        sqe->cancel_flags |= IOSQE_FIXED_FILE;
+    }
+
+    reg_fds_.erase(it);
+    submit_cnt_++;
+    return 0;
+}
+
+int RingListener::SubmitRegisterFile(brpc::Socket *sock, int *fd, int32_t fd_idx) {
+    io_uring_sqe *sqe = io_uring_get_sqe(&ring_);
+    if (sqe == nullptr) {
+        LOG(ERROR) << "IO uring submission queue is full for the inbound "
+                "listener, group: "
+             << task_group_->group_id_;
+        return -1;
+    }
+
+    io_uring_prep_files_update(sqe, fd, 1, fd_idx);
+    uint64_t data = reinterpret_cast<uint64_t>(sock);
+    data = data << 16;
+    data |= OpCodeToInt(OpCode::RegisterFile);
+    io_uring_sqe_set_data64(sqe, data);
+    sock->reg_fd_idx_ = fd_idx;
+
+    ++submit_cnt_;
+    return 0;
+}
+
+void RingListener::HandleCqe(io_uring_cqe *cqe) {
+    uint64_t data = io_uring_cqe_get_data64(cqe);
+    OpCode op = IntToOpCode(data & UINT8_MAX);
+
+    switch (op) {
+        case OpCode::Recv: {
+            brpc::Socket *sock = reinterpret_cast<brpc::Socket *>(data >> 16);
+            HandleRecv(sock, cqe);
+            break;
+        }
+        case OpCode::CancelRecv: {
+            if (cqe->res < 0) {
+                LOG(ERROR) << "Failed to cancel socket recv, errno: " << cqe->res
+                        << ", group: " << task_group_->group_id_;
+            }
+            data = data >> 16;
+            // If the fd is a registered file, recycles the fixed file slot.
+            if (data < UINT16_MAX) {
+                uint16_t fd_idx = (uint16_t) data;
+                free_reg_fd_idx_.emplace_back(fd_idx);
+            }
+            break;
+        }
+        case OpCode::RegisterFile: {
+            brpc::Socket *sock = reinterpret_cast<brpc::Socket *>(data >> 16);
+            if (cqe->res < 0) {
+                LOG(WARNING) << "IO uring file registration failed, errno: " << cqe->res
+                        << ", group: " << task_group_->group_id_
+                        << ", socket: " << *sock;
+                free_reg_fd_idx_.emplace_back(sock->reg_fd_idx_);
+                sock->reg_fd_idx_ = -1;
+                auto it = reg_fds_.find(sock->fd());
+                assert(it != reg_fds_.end());
+                it->second = -1;
+            }
+            SubmitRecv(sock);
+            break;
+        }
+        case OpCode::FixedWrite: {
+            brpc::Socket *sock = reinterpret_cast<brpc::Socket *>(data >> 16);
+            HandleFixedWrite(sock, cqe->res, sock->write_buf_idx_);
+            break;
+        }
+        case OpCode::NonFixedWrite: {
+            brpc::Socket *sock = reinterpret_cast<brpc::Socket *>(data >> 16);
+            sock->RingNonFixedWriteCb(cqe->res);
+            break;
+        }
+        case OpCode::WaitingNonFixedWrite: {
+            brpc::Socket *sock = reinterpret_cast<brpc::Socket *>(data >> 16);
+            sock->NotifyWaitingNonFixedWrite(cqe->res);
+            break;
+        }
+        case OpCode::Fsync: {
+            RingFsyncData *fsync_data = reinterpret_cast<RingFsyncData *>(data >> 16);
+            int res = cqe->res;
+            fsync_data->Notify(res);
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+void RingListener::HandleRecv(brpc::Socket *sock, io_uring_cqe *cqe) {
+    int32_t nw = cqe->res;
+    uint16_t buf_id = UINT16_MAX;
+    bool need_rearm = false;
+
+    assert(sock != nullptr);
+
+    if (nw < 0) {
+        int err = -nw;
+        if (err == ENOBUFS) {
+            // There aren't enough buffers for the recv request. Retries the
+            // request.
+            uint64_t data = OpCodeToInt(OpCode::Recv);
+            bool success = SubmitBacklog(sock, data);
+            if (success) {
+                return;
+            }
+        }
+
+        if (err == EAGAIN || err == EINTR || err == ENOBUFS) {
+            need_rearm = true;
+        }
+    } else {
+        // Not having a buffer attached should only happen if we get a zero sized
+        // receive, because the other end closed the connection. It cannot happen
+        // otherwise, as all our receives are using provided buffers and hence
+        // it's not possible to return a CQE with a non-zero result and not have a
+        // buffer attached.
+        if (cqe->flags & IORING_CQE_F_BUFFER) {
+            buf_id = cqe->flags >> IORING_CQE_BUFFER_SHIFT;
+            CHECK(nw > 0);
+        }
+
+        // If IORING_CQE_F_MORE isn't set, this multishot recv won't post any
+        // further completions.
+        if (!(cqe->flags & IORING_CQE_F_MORE)) {
+            need_rearm = true;
+        }
+    }
+
+    InboundRingBuf in_buf{sock, nw, buf_id, need_rearm};
+    brpc::Socket::SocketResume(sock, in_buf, task_group_);
+}
+
+void RingListener::HandleFixedWrite(brpc::Socket *sock, int nw, uint16_t write_buf_idx) {
+    // Fixed write finished. Deferences the socket, until the write is retried.
+    brpc::SocketUniquePtr sock_uptr(sock);
+
+    if (nw >= 0) {
+        CHECK(sock->write_len_ >= nw);
+        sock->write_len_ -= nw;
+        if (sock->write_len_ == 0) {
+            // Data fully written, recycle the write buffer.
+            RecycleWriteBuf(write_buf_idx);
+            return;
+        }
+        // Data not fully written, shift the data and submit again.
+        const char *write_buf = write_buf_pool_->GetBuf(write_buf_idx);
+        std::memmove(const_cast<char *>(write_buf), write_buf + nw, sock->write_len_);
+        int ret = SubmitFixedWrite(sock, write_buf_idx);
+        if (ret == 0) {
+            // Does not dereference the socket because the write is retried.
+            (void) sock_uptr.release();
+        } else {
+            // TODO(zkl)
+        }
+    } else {
+        // Fixed write failed. If the errorno is EAGAIN, retries the write.
+        LOG(ERROR) << "fixed write error, sock: " << *sock
+                << ", errno: " << -nw;
+        int err = -nw;
+        if (err == EAGAIN) {
+            int ret = SubmitFixedWrite(sock, write_buf_idx);
+            if (ret == 0) {
+                // Does not dereference the socket because the write is retried.
+                (void) sock_uptr.release();
+            } else {
+                // TODO(zkl)
+            }
+        } else {
+            // EPIPE is common in pooled connections + backup requests.
+            PLOG_IF(WARNING, err != EPIPE) << "Fail to write into " << *sock;
+            sock->SetFailed(err, "Fail to write into %s: %s",
+                            sock->description().c_str(), berror(err));
+            RecycleWriteBuf(write_buf_idx);
+        }
+    }
+}
+
+void RingListener::HandleBacklog() {
+    while (waiting_cnt_.load(std::memory_order_relaxed) > 0) {
+        size_t cnt = waiting_socks_.TryDequeueBulk(waiting_batch_.begin(),
+                                                   waiting_batch_.size());
+        for (size_t idx = 0; idx < cnt; ++idx) {
+            brpc::Socket *sock = waiting_batch_[idx].first;
+            uint64_t data = waiting_batch_[idx].second;
+            OpCode op = IntToOpCode(data & UINT8_MAX);
+            switch (op) {
+                case OpCode::Recv:
+                    SubmitRecv(sock);
+                    break;
+                case OpCode::FixedWriteFinish: {
+                    int nw = (int) (data >> 32);
+                    HandleFixedWrite(sock, nw, sock->write_buf_idx_);
+                    break;
+                }
+                case OpCode::NonFixedWriteFinish: {
+                    int nw = (int) (data >> 32);
+                    sock->RingNonFixedWriteCb(nw);
+                    break;
+                }
+                case OpCode::WaitingNonFixedWrite: {
+                    SubmitWaitingNonFixedWrite(sock);
+                    break;
+                }
+                default:
+                    LOG(FATAL) << "backlog has an unsupported op, " << (int) op;
+                    break;
+            }
+        }
+        waiting_cnt_.fetch_sub(cnt, std::memory_order_release);
+    }
+}
+
+bool RingListener::SubmitBacklog(brpc::Socket *sock, uint64_t data) {
+    waiting_cnt_.fetch_add(1, std::memory_order_relaxed);
+    bool success = waiting_socks_.TryEnqueue(std::make_pair(sock, data));
+    if (!success) {
+        waiting_cnt_.fetch_sub(1, std::memory_order_relaxed);
+    }
+
+    return success;
+}
+
+#endif

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -422,24 +422,6 @@ void RingListener::Run() {
                    PollStatus::Closed;
         });
     }
-    // while (poll_status_.load(std::memory_order_relaxed) != PollStatus::Closed) {
-    //     if (reg_cnt_.load(std::memory_order_acquire) > 0 &&
-    //         !has_external_.load(std::memory_order_relaxed)) {
-    //         PollStatus status = PollStatus::Sleep;
-    //         if (poll_status_.compare_exchange_strong(status, PollStatus::Active,
-    //                                                  std::memory_order_acq_rel)) {
-    //             PollAndNotify();
-    //         }
-    //     }
-    //     poll_status_.store(PollStatus::Sleep, std::memory_order_acq_rel);
-    //     std::unique_lock<std::mutex> lk(mux_);
-    //     cv_.wait(lk, [this]() {
-    //         return (reg_cnt_.load(std::memory_order_acquire) > 0 &&
-    //                 !has_external_.load(std::memory_order_relaxed)) ||
-    //                poll_status_.load(std::memory_order_relaxed) ==
-    //                PollStatus::Closed;
-    //     });
-    // }
 }
 
 void RingListener::RecycleReadBuf(uint16_t bid, size_t bytes) {

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -19,7 +19,6 @@
 
 #ifdef IO_URING_ENABLED
 #include "brpc/socket.h"
-// #include "bthread/task_control.h"
 #include "bthread/task_group.h"
 #include "bthread/brpc_module.h"
 #include "bthread/inbound_ring_buf.h"
@@ -347,13 +346,11 @@ void RingListener::PollAndNotify() {
     }
     cqe_ready_.store(true, std::memory_order_relaxed);
     poll_status_.store(PollStatus::Sleep, std::memory_order_relaxed);
-    // LOG(INFO) << "RingModule notify worker: " << task_group_->group_id_;
     RingModule::NotifyWorker(task_group_->group_id_);
 }
 
 
 size_t RingListener::ExtPoll() {
-    // LOG(INFO) << "RingListener::ExtPoll, group: " << task_group_->group_id_;
     if (!has_external_.load(std::memory_order_relaxed)) {
         has_external_.store(true, std::memory_order_release);
     }

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -28,10 +28,6 @@
 
 #include "ring_listener.h"
 
-// namespace bthread {
-//     extern TaskControl *get_task_control();
-// }
-
 RingListener::~RingListener() {
     for (auto [fd, fd_idx]: reg_fds_) {
         SubmitCancel(fd);
@@ -92,8 +88,6 @@ int RingListener::Init() {
     io_uring_buf_ring_advance(in_buf_ring_, buf_ring_size);
 
     write_buf_pool_ = std::make_unique<RingWriteBufferPool>(1024, &ring_);
-
-    // ring_module_ = bthread::get_task_control()->get_ring_module();
 
     poll_status_.store(PollStatus::Sleep, std::memory_order_release);
     poll_thd_ = std::thread([&]() {

--- a/src/bthread/ring_listener.h
+++ b/src/bthread/ring_listener.h
@@ -32,8 +32,8 @@
 #include "brpc/socket.h"
 #include "bthread/inbound_ring_buf.h"
 #include "bthread/ring_write_buf_pool.h"
-#include "bthread/task_group.h"
 #include "butil/threading/platform_thread.h"
+#include "spsc_queue.h"
 
 namespace bthread {
     extern BAIDU_THREAD_LOCAL TaskGroup *tls_task_group;
@@ -67,80 +67,9 @@ public:
     RingListener(bthread::TaskGroup *group) : task_group_(group) {
     }
 
-    ~RingListener() {
-        for (auto [fd, fd_idx]: reg_fds_) {
-            SubmitCancel(fd);
-        }
-        SubmitAll();
+    ~RingListener();
 
-        poll_status_.store(PollStatus::Closed, std::memory_order_release); {
-            std::unique_lock<std::mutex> lk(mux_);
-            cv_.notify_one();
-        }
-
-        if (poll_thd_.joinable()) {
-            poll_thd_.join();
-        }
-        Close();
-    }
-
-    int Init() {
-        int ret = io_uring_queue_init(1024, &ring_, IORING_SETUP_SINGLE_ISSUER);
-
-        if (ret < 0) {
-            LOG(WARNING) << "Failed to initialize the IO uring of the inbound "
-                      "listener, errno: "
-                   << ret;
-            Close();
-            return ret;
-        }
-        ring_init_ = true;
-
-        ret = io_uring_register_files_sparse(&ring_, 1024);
-        if (ret < 0) {
-            LOG(WARNING)
-          << "Failed to register sparse files for the inbound listener.";
-            Close();
-            return ret;
-        }
-
-        free_reg_fd_idx_.reserve(1024);
-        for (uint16_t f_idx = 0; f_idx < 1024; ++f_idx) {
-            free_reg_fd_idx_.emplace_back(f_idx);
-        }
-
-        in_buf_ =
-                (char *) std::aligned_alloc(buf_length, buf_length * buf_ring_size);
-        in_buf_ring_ = io_uring_setup_buf_ring(&ring_, buf_ring_size, 0, 0, &ret);
-        if (in_buf_ring_ == nullptr) {
-            LOG(WARNING)
-          << "Failed to register buffer ring for the inbound listener.";
-            Close();
-            return -1;
-        }
-
-        char *ptr = in_buf_;
-        // inbound_ring_size must be the power of 2.
-        int br_mask = buf_ring_size - 1;
-        for (size_t idx = 0; idx < buf_ring_size; idx++) {
-            io_uring_buf_ring_add(in_buf_ring_, ptr, buf_length, idx, br_mask, idx);
-            ptr += buf_length;
-        }
-        io_uring_buf_ring_advance(in_buf_ring_, buf_ring_size);
-
-        write_buf_pool_ = std::make_unique<RingWriteBufferPool>(1024, &ring_);
-
-        poll_status_.store(PollStatus::Sleep, std::memory_order_release);
-        poll_thd_ = std::thread([&]() {
-            std::string ring_listener = "ring_listener:";
-            ring_listener.append(std::to_string(task_group_->group_id_));
-            butil::PlatformThread::SetName(ring_listener.c_str());
-
-            Run();
-        });
-
-        return 0;
-    }
+    int Init();
 
     void Close() {
         if (ring_init_) {
@@ -154,346 +83,39 @@ public:
         }
     }
 
-    int Register(brpc::Socket *sock) {
-        int fd = sock->fd();
-        CHECK(fd>=0);
+    int Register(brpc::Socket *sock);
 
-        auto it = reg_fds_.find(fd);
-        if (it != reg_fds_.end()) {
-            LOG(WARNING) << "Socket " << sock->id() << ", fd: " << sock->fd()
-                   << " has been registered before.";
-            return -1;
-        }
+    int SubmitRecv(brpc::Socket *sock);
 
-        sock->reg_fd_idx_ = -1;
-        int ret = -1;
+    int SubmitFixedWrite(brpc::Socket *sock, uint16_t ring_buf_idx);
 
-        if (free_reg_fd_idx_.empty()) {
-            // All registered file slots have been taken. Cannot register the socket's
-            // fd.
-            reg_fds_.try_emplace(fd, -1);
-            ret = SubmitRecv(sock);
-        } else {
-            uint16_t fd_idx = free_reg_fd_idx_.back();
-            free_reg_fd_idx_.pop_back();
-            reg_fds_.try_emplace(fd, fd_idx);
-            sock->reg_fd_ = fd;
-            sock->reg_fd_idx_ = fd_idx;
-            ret = SubmitRegisterFile(sock, &sock->reg_fd_, fd_idx);
-        }
+    int SubmitNonFixedWrite(brpc::Socket *sock);
 
-        if (ret < 0) {
-            reg_fds_.erase(fd);
-            return -1;
-        }
+    int SubmitWaitingNonFixedWrite(brpc::Socket *sock);
 
-        return 0;
-    }
-
-    int SubmitRecv(brpc::Socket *sock) {
-        io_uring_sqe *sqe = io_uring_get_sqe(&ring_);
-        if (sqe == nullptr) {
-            LOG(ERROR) << "IO uring submission queue is full for the inbound "
-                    "listener, group: "
-                 << task_group_->group_id_;
-            return -1;
-        }
-        int fd_idx = sock->reg_fd_idx_;
-        int sfd = fd_idx >= 0 ? fd_idx : sock->fd();
-        io_uring_prep_recv_multishot(sqe, sfd, NULL, 0, 0);
-        uint64_t data = reinterpret_cast<uint64_t>(sock);
-        data = data << 16;
-        data |= OpCodeToInt(OpCode::Recv);
-        io_uring_sqe_set_data64(sqe, data);
-
-        sqe->buf_group = 0;
-        sqe->flags |= IOSQE_BUFFER_SELECT;
-        if (fd_idx >= 0) {
-            sqe->flags |= IOSQE_FIXED_FILE;
-        }
-        // sqe->ioprio |= IORING_RECVSEND_BUNDLE;
-
-        ++submit_cnt_;
-        return 0;
-    }
-
-    int SubmitFixedWrite(brpc::Socket *sock, uint16_t ring_buf_idx) {
-        io_uring_sqe *sqe = io_uring_get_sqe(&ring_);
-        if (sqe == nullptr) {
-            LOG(ERROR)
-                << "IO uring submission queue is full for the ring listener, group: "
-                << task_group_->group_id_;
-            return -1;
-        }
-
-        int fd_idx = -1;
-        // Use registered index if this socket is bound to this group and ring.
-        if (bthread::tls_task_group == sock->bound_g_) {
-            fd_idx = sock->reg_fd_idx_;
-        }
-        int sfd = fd_idx >= 0 ? fd_idx : sock->fd();
-        // LOG(INFO) << "SubmitFixedWrite tls_task_group: " << bthread::tls_task_group
-        //     << ", socket bound task_group: " << sock->bound_g_
-        //     << ", sfd: " << sfd << ", fd_idx: " << fd_idx
-        //     << ", socket: " << *sock;
-
-        const char *write_buf = write_buf_pool_->GetBuf(ring_buf_idx);
-        sock->write_buf_idx_ = ring_buf_idx;
-
-        io_uring_prep_write_fixed(sqe, sfd, write_buf, sock->write_len_, 0,
-                                  ring_buf_idx);
-
-        uint64_t data = reinterpret_cast<uint64_t>(sock);
-        data = data << 16;
-        data |= OpCodeToInt(OpCode::FixedWrite);
-        io_uring_sqe_set_data64(sqe, data);
-        if (fd_idx >= 0) {
-            sqe->flags |= IOSQE_FIXED_FILE;
-        }
-
-        ++submit_cnt_;
-        return 0;
-    }
-
-    int SubmitNonFixedWrite(brpc::Socket *sock) {
-        io_uring_sqe *sqe = io_uring_get_sqe(&ring_);
-        if (sqe == nullptr) {
-            LOG(ERROR)
-              << "IO uring submission queue is full for the ring listener, group: "
-              << task_group_->group_id_;
-            return -1;
-        }
-
-        int fd_idx = -1;
-        // Use registered index if this socket is bound to this group and ring.
-        if (bthread::tls_task_group == sock->bound_g_) {
-            fd_idx = sock->reg_fd_idx_;
-        }
-        int sfd = fd_idx >= 0 ? fd_idx : sock->fd();
-        // LOG(INFO) << "SubmitNonFixedWrite tls_task_group: " << bthread::tls_task_group
-        //     << ", socket bound task_group: " << sock->bound_g_
-        //     << ", sfd: " << sfd << ", fd_idx: " << fd_idx
-        //     << ", socket: " << *sock;
-
-        CHECK(sock->iovecs_.size() <= IOV_MAX);
-        io_uring_prep_writev(sqe, sfd, sock->iovecs_.data(), sock->iovecs_.size(),
-                             0);
-
-        uint64_t size = 0;
-        std::string total_data;
-        for (auto &iovec: sock->iovecs_) {
-            size += iovec.iov_len;
-            total_data.append(static_cast<char *>(iovec.iov_base), iovec.iov_len);
-        }
-        // LOG(INFO) << "SubmitNonFixedWrite() sock->iovecs size: " << sock->iovecs_.size()
-        //     << " data total size: " << size
-        //     << " socket: " << *sock << ", fd_idx: " << fd_idx
-        //     << " total data: " << total_data;
-
-        uint64_t data = reinterpret_cast<uint64_t>(sock);
-        data = data << 16;
-        data |= OpCodeToInt(OpCode::NonFixedWrite);
-        io_uring_sqe_set_data64(sqe, data);
-
-        if (fd_idx >= 0) {
-            sqe->flags |= IOSQE_FIXED_FILE;
-        }
-
-        ++submit_cnt_;
-        return 0;
-    }
-
-    int SubmitWaitingNonFixedWrite(brpc::Socket *sock) {
-        io_uring_sqe *sqe = io_uring_get_sqe(&ring_);
-        if (sqe == nullptr) {
-            LOG(ERROR)
-              << "IO uring submission queue is full for the ring listener, group: "
-              << task_group_->group_id_;
-            uint64_t data = 0;
-            data |= OpCodeToInt(OpCode::WaitingNonFixedWrite);
-            if (SubmitBacklog(sock, data)) {
-                return 0;
-            }
-            return -1;
-        }
-
-        int fd_idx = -1;
-        // Use registered index if this socket is bound to this group and ring.
-        if (bthread::tls_task_group == sock->bound_g_) {
-            fd_idx = sock->reg_fd_idx_;
-        }
-        int sfd = fd_idx >= 0 ? fd_idx : sock->fd();
-        // LOG(INFO) << "SubmitWaitingNonFixedWrite tls_task_group: " << bthread::tls_task_group
-        //     << ", socket bound task_group: " << sock->bound_g_
-        //     << ", sfd: " << sfd << ", fd_idx: " << fd_idx
-        //     << ", socket: " << *sock;
-
-        CHECK(sock->iovecs_.size() <= IOV_MAX);
-
-        io_uring_prep_writev(sqe, sfd, sock->iovecs_.data(), sock->iovecs_.size(),
-                             0);
-        uint64_t size = 0;
-        std::string total_data;
-        for (auto &iovec: sock->iovecs_) {
-            size += iovec.iov_len;
-            total_data.append(static_cast<char *>(iovec.iov_base), iovec.iov_len);
-        }
-        // LOG(INFO) << "SubmitWaitingNonFixedWrite() sock->iovecs size: " << sock->iovecs_.size()
-        //     << " data total size: " << size
-        //     << " socket: " << *sock << ", fd_idx: " << fd_idx
-        //     << " total data: " << total_data;
-
-        uint64_t data = reinterpret_cast<uint64_t>(sock);
-        data = data << 16;
-        data |= OpCodeToInt(OpCode::WaitingNonFixedWrite);
-        io_uring_sqe_set_data64(sqe, data);
-
-        if (fd_idx >= 0) {
-            sqe->flags |= IOSQE_FIXED_FILE;
-        }
-
-        ++submit_cnt_;
-        return 0;
-    }
-
-    int SubmitFsync(RingFsyncData *args) {
-        io_uring_sqe *sqe = io_uring_get_sqe(&ring_);
-        if (sqe == nullptr) {
-            LOG(ERROR)
-              << "IO uring submission queue is full for the ring listener, group: "
-              << task_group_->group_id_;
-            return -1;
-        }
-
-        io_uring_prep_fsync(sqe, args->fd_, 0);
-        uint64_t data = reinterpret_cast<uint64_t>(args);
-        data = data << 16;
-        data |= OpCodeToInt(OpCode::Fsync);
-        io_uring_sqe_set_data64(sqe, data);
-        ++submit_cnt_;
-        return 0;
-    }
+    int SubmitFsync(RingFsyncData *args);
 
     bool HasJobsToSubmit() const {
         return submit_cnt_ > 0;
     }
 
-    int SubmitAll() {
-        if (submit_cnt_ == 0) {
-            return 0;
-        }
-
-        int ret = io_uring_submit(&ring_);
-        if (ret >= 0) {
-            submit_cnt_ = submit_cnt_ >= ret ? submit_cnt_ - ret : 0;
-        } else {
-            // IO uring submission failed. Clears the submission count.
-            submit_cnt_ = 0;
-            LOG(ERROR) << "Failed to flush the IO uring submission queue for the "
-                    "inbound listener.";
-        }
-        return ret;
+    bool HasTasks() const {
+        return submit_cnt_ > 0 || cqe_ready_.load(std::memory_order_relaxed);
     }
+
+    int SubmitAll();
 
     void Unregister(int fd) { SubmitCancel(fd); }
 
-    void PollAndNotify() {
-        io_uring_cqe *cqe = nullptr;
-        int ret = io_uring_wait_cqe(&ring_, &cqe);
-        if (ret < 0) {
-            LOG(ERROR) << "Listener uring wait errno: " << ret;
-            return;
-        }
-        cqe_ready_.store(true);
-        poll_status_.store(PollStatus::Sleep);
-        task_group_->RingListenerNotify();
-    }
+    void PollAndNotify();
 
-    size_t ExtPoll() {
-        if (!has_external_.load(std::memory_order_relaxed)) {
-            has_external_.store(true, std::memory_order_release);
-        }
+    size_t ExtPoll();
 
-        // has_external_ should be updated before poll_status_ is checked.
-        std::atomic_thread_fence(std::memory_order_release);
+    void ExtWakeup();
 
-        PollStatus status = PollStatus::Sleep;
-        if (!poll_status_.compare_exchange_strong(status, PollStatus::ExtPoll)) {
-            return 0;
-        }
+    void Run();
 
-        HandleBacklog();
-
-        io_uring_cqe *cqe = nullptr;
-        int ret = io_uring_peek_cqe(&ring_, &cqe);
-        if (ret != 0) {
-            poll_status_.store(PollStatus::Sleep, std::memory_order_relaxed);
-            return 0;
-        }
-
-        int processed = 0;
-        unsigned int head;
-        io_uring_for_each_cqe(&ring_, head, cqe) {
-            HandleCqe(cqe, true);
-            ++processed;
-        }
-
-        if (processed > 0) {
-            io_uring_cq_advance(&ring_, processed);
-        }
-
-        cqe_ready_.store(false, std::memory_order_relaxed);
-        poll_status_.store(PollStatus::Sleep, std::memory_order_relaxed);
-        return processed;
-    }
-
-    void ExtWakeup() {
-        has_external_.store(false, std::memory_order_relaxed);
-        if (poll_status_.load(std::memory_order_relaxed) != PollStatus::Sleep) {
-            return;
-        }
-        std::unique_lock<std::mutex> lk(mux_);
-        cv_.notify_one();
-    }
-
-    void Run() {
-        while (poll_status_.load(std::memory_order_relaxed) != PollStatus::Closed) {
-            bool success = false;
-            if (!has_external_.load(std::memory_order_relaxed)) {
-                PollStatus status = PollStatus::Sleep;
-                success = poll_status_.compare_exchange_strong(status, PollStatus::Active,
-                                                               std::memory_order_acq_rel);
-                if (success) {
-                    PollAndNotify();
-                }
-            }
-            std::unique_lock<std::mutex> lk(mux_);
-            cv_.wait(lk, [this]() {
-                // wait for the worker to process the ready cqes and notify RingListener when it sleeps
-                return !has_external_.load(std::memory_order_relaxed)
-                       && !cqe_ready_.load(std::memory_order_relaxed) ||
-                       poll_status_.load(std::memory_order_relaxed) ==
-                       PollStatus::Closed;
-            });
-        }
-    }
-
-    void RecycleReadBuf(uint16_t bid, size_t bytes) {
-        // The socket has finished processing inbound messages. Returns the borrowed
-        // buffers to the buffer ring.
-        int br_mask = buf_ring_size - 1;
-        int buf_cnt = 0;
-        while (bytes > 0) {
-            char *this_buf = in_buf_ + bid * buf_length;
-            io_uring_buf_ring_add(in_buf_ring_, this_buf, buf_length, bid, br_mask,
-                                  buf_cnt);
-
-            bytes = bytes > buf_length ? bytes - buf_length : 0;
-            bid = (bid + 1) & br_mask;
-            buf_cnt++;
-        }
-        io_uring_buf_ring_advance(in_buf_ring_, buf_cnt);
-    }
+    void RecycleReadBuf(uint16_t bid, size_t bytes);
 
     const char *GetReadBuf(uint16_t bid) const {
         return in_buf_ + bid * buf_length;
@@ -510,156 +132,11 @@ private:
         }
     }
 
-    int SubmitCancel(int fd) {
-        io_uring_sqe *sqe = io_uring_get_sqe(&ring_);
-        if (sqe == nullptr) {
-            LOG(ERROR) << "IO uring submission queue is full for the inbound "
-                    "listener, group: "
-                 << task_group_->group_id_;
-            return -1;
-        }
+    int SubmitCancel(int fd);
 
-        auto it = reg_fds_.find(fd);
-        if (it == reg_fds_.end()) {
-            return 0;
-        }
+    int SubmitRegisterFile(brpc::Socket *sock, int *fd, int32_t fd_idx);
 
-        int fd_idx = it->second;
-        int sfd;
-        uint64_t data;
-
-        int flags = 0;
-        if (fd_idx >= 0) {
-            flags |= IORING_ASYNC_CANCEL_FD_FIXED;
-            sfd = fd_idx;
-            data = fd_idx << 16;
-        } else {
-            sfd = fd;
-            data = UINT16_MAX << 16;
-        }
-
-        io_uring_prep_cancel_fd(sqe, sfd, flags);
-        data |= OpCodeToInt(OpCode::CancelRecv);
-        io_uring_sqe_set_data64(sqe, data);
-        if (fd_idx >= 0) {
-            sqe->cancel_flags |= IOSQE_FIXED_FILE;
-        }
-
-        reg_fds_.erase(it);
-        submit_cnt_++;
-        return 0;
-    }
-
-    int SubmitRegisterFile(brpc::Socket *sock, int *fd, int32_t fd_idx) {
-        io_uring_sqe *sqe = io_uring_get_sqe(&ring_);
-        if (sqe == nullptr) {
-            LOG(ERROR) << "IO uring submission queue is full for the inbound "
-                    "listener, group: "
-                 << task_group_->group_id_;
-            return -1;
-        }
-
-        io_uring_prep_files_update(sqe, fd, 1, fd_idx);
-        uint64_t data = reinterpret_cast<uint64_t>(sock);
-        data = data << 16;
-        data |= OpCodeToInt(OpCode::RegisterFile);
-        io_uring_sqe_set_data64(sqe, data);
-        sock->reg_fd_idx_ = fd_idx;
-
-        ++submit_cnt_;
-        return 0;
-    }
-
-    void HandleCqe(io_uring_cqe *cqe, bool is_group_worker) {
-        uint64_t data = io_uring_cqe_get_data64(cqe);
-        OpCode op = IntToOpCode(data & UINT8_MAX);
-
-        switch (op) {
-            case OpCode::Recv: {
-                brpc::Socket *sock = reinterpret_cast<brpc::Socket *>(data >> 16);
-                HandleRecv(sock, cqe, is_group_worker);
-                break;
-            }
-            case OpCode::CancelRecv: {
-                if (cqe->res < 0) {
-                    LOG(ERROR) << "Failed to cancel socket recv, errno: " << cqe->res
-                        << ", group: " << task_group_->group_id_;
-                }
-                data = data >> 16;
-                // If the fd is a registered file, recycles the fixed file slot.
-                if (data < UINT16_MAX) {
-                    uint16_t fd_idx = (uint16_t) data;
-                    free_reg_fd_idx_.emplace_back(fd_idx);
-                }
-                break;
-            }
-            case OpCode::RegisterFile: {
-                brpc::Socket *sock = reinterpret_cast<brpc::Socket *>(data >> 16);
-                if (cqe->res < 0) {
-                    LOG(WARNING) << "IO uring file registration failed, errno: " << cqe->res
-                        << ", group: " << task_group_->group_id_
-                        << ", socket: " << *sock;
-                    free_reg_fd_idx_.emplace_back(sock->reg_fd_idx_);
-                    sock->reg_fd_idx_ = -1;
-                    auto it = reg_fds_.find(sock->fd());
-                    assert(it != reg_fds_.end());
-                    it->second = -1;
-                }
-                SubmitRecv(sock);
-                break;
-            }
-            case OpCode::FixedWrite: {
-                brpc::Socket *sock = reinterpret_cast<brpc::Socket *>(data >> 16);
-                if (is_group_worker) {
-                    HandleFixedWrite(sock, cqe->res, sock->write_buf_idx_);
-                } else {
-                    // Handling the fixed write result will recycle the write buffer, which
-                    // accesses the write buffer pool that can only be accessed by the task
-                    // group worker. If this is not the task group worker, puts result
-                    // handling to the backlog queue.
-                    uint64_t data = (uint32_t) cqe->res;
-                    data = data << 32;
-                    data |= OpCodeToInt(OpCode::FixedWriteFinish);
-                    bool success = SubmitBacklog(sock, data);
-                    LOG_IF(FATAL, !success)
-                        << "Fixed write needs to be handled by the task group worker, but "
-                           "the backlog queue is full, task group: "
-                        << task_group_->group_id_;
-                }
-
-                break;
-            }
-            case OpCode::NonFixedWrite: {
-                brpc::Socket *sock = reinterpret_cast<brpc::Socket *>(data >> 16);
-                if (is_group_worker) {
-                    sock->RingNonFixedWriteCb(cqe->res);
-                } else {
-                    uint64_t data = (uint32_t) cqe->res;
-                    data = data << 32;
-                    data |= OpCodeToInt(OpCode::NonFixedWriteFinish);
-                    bool success = SubmitBacklog(sock, data);
-                    LOG_IF(FATAL, !success)
-                        << "Non-fixed write needs to be handled by the task group worker, "
-                           "but the backlog queue is full, task group: "
-                        << task_group_->group_id_;
-                }
-                break;
-            }
-            case OpCode::WaitingNonFixedWrite: {
-                brpc::Socket *sock = reinterpret_cast<brpc::Socket *>(data >> 16);
-                sock->NotifyWaitingNonFixedWrite(cqe->res);
-                break;
-            }
-            case OpCode::Fsync: {
-                RingFsyncData *fsync_data = reinterpret_cast<RingFsyncData *>(data >> 16);
-                int res = cqe->res;
-                fsync_data->Notify(res);
-                break;
-            }
-            default:
-                break;
-        }
-    }
+    void HandleCqe(io_uring_cqe *cqe);
 
     enum struct OpCode : uint8_t {
         Recv = 0,
@@ -724,147 +201,13 @@ private:
         }
     }
 
-    void HandleRecv(brpc::Socket *sock, io_uring_cqe *cqe, bool is_group_worker) {
-        int32_t nw = cqe->res;
-        uint16_t buf_id = UINT16_MAX;
-        bool need_rearm = false;
+    void HandleRecv(brpc::Socket *sock, io_uring_cqe *cqe);
 
-        assert(sock != nullptr);
+    void HandleFixedWrite(brpc::Socket *sock, int nw, uint16_t write_buf_idx);
 
-        if (nw < 0) {
-            int err = -nw;
-            if (err == ENOBUFS) {
-                // There aren't enough buffers for the recv request. Retries the
-                // request.
-                uint64_t data = OpCodeToInt(OpCode::Recv);
-                bool success = SubmitBacklog(sock, data);
-                if (success) {
-                    return;
-                }
-            }
+    void HandleBacklog();
 
-            if (err == EAGAIN || err == EINTR || err == ENOBUFS) {
-                need_rearm = true;
-            }
-        } else {
-            // Not having a buffer attached should only happen if we get a zero sized
-            // receive, because the other end closed the connection. It cannot happen
-            // otherwise, as all our receives are using provided buffers and hence
-            // it's not possible to return a CQE with a non-zero result and not have a
-            // buffer attached.
-            if (cqe->flags & IORING_CQE_F_BUFFER) {
-                buf_id = cqe->flags >> IORING_CQE_BUFFER_SHIFT;
-                CHECK(nw > 0);
-            }
-
-            // If IORING_CQE_F_MORE isn't set, this multishot recv won't post any
-            // further completions.
-            if (!(cqe->flags & IORING_CQE_F_MORE)) {
-                need_rearm = true;
-            }
-        }
-
-        if (is_group_worker) {
-            InboundRingBuf in_buf{sock, nw, buf_id, need_rearm};
-            brpc::Socket::SocketResume(sock, in_buf, task_group_);
-        } else {
-            bool success =
-                    task_group_->EnqueueInboundRingBuf(sock, nw, buf_id, need_rearm);
-            LOG_IF(FATAL, !success)
-                << "Inbound ring buffer failed to enqueue, group: "
-                << task_group_->group_id_;
-        }
-    }
-
-    void HandleFixedWrite(brpc::Socket *sock, int nw, uint16_t write_buf_idx) {
-        // Fixed write finished. Deferences the socket, until the write is retried.
-        brpc::SocketUniquePtr sock_uptr(sock);
-
-        if (nw >= 0) {
-            CHECK(sock->write_len_ >= nw);
-            sock->write_len_ -= nw;
-            if (sock->write_len_ == 0) {
-                // Data fully written, recycle the write buffer.
-                RecycleWriteBuf(write_buf_idx);
-                return;
-            }
-            // Data not fully written, shift the data and submit again.
-            const char *write_buf = write_buf_pool_->GetBuf(write_buf_idx);
-            std::memmove(const_cast<char *>(write_buf), write_buf + nw, sock->write_len_);
-            int ret = SubmitFixedWrite(sock, write_buf_idx);
-            if (ret == 0) {
-                // Does not dereference the socket because the write is retried.
-                (void) sock_uptr.release();
-            } else {
-                // TODO(zkl)
-            }
-        } else {
-            // Fixed write failed. If the errorno is EAGAIN, retries the write.
-            LOG(ERROR) << "fixed write error, sock: " << *sock
-                << ", errno: " << -nw;
-            int err = -nw;
-            if (err == EAGAIN) {
-                int ret = SubmitFixedWrite(sock, write_buf_idx);
-                if (ret == 0) {
-                    // Does not dereference the socket because the write is retried.
-                    (void) sock_uptr.release();
-                } else {
-                    // TODO(zkl)
-                }
-            } else {
-                // EPIPE is common in pooled connections + backup requests.
-                PLOG_IF(WARNING, err != EPIPE) << "Fail to write into " << *sock;
-                sock->SetFailed(err, "Fail to write into %s: %s",
-                                sock->description().c_str(), berror(err));
-                RecycleWriteBuf(write_buf_idx);
-            }
-        }
-    }
-
-    void HandleBacklog() {
-        while (waiting_cnt_.load(std::memory_order_relaxed) > 0) {
-            size_t cnt = waiting_socks_.TryDequeueBulk(waiting_batch_.begin(),
-                                                       waiting_batch_.size());
-            for (size_t idx = 0; idx < cnt; ++idx) {
-                brpc::Socket *sock = waiting_batch_[idx].first;
-                uint64_t data = waiting_batch_[idx].second;
-                OpCode op = IntToOpCode(data & UINT8_MAX);
-                switch (op) {
-                    case OpCode::Recv:
-                        SubmitRecv(sock);
-                        break;
-                    case OpCode::FixedWriteFinish: {
-                        int nw = (int) (data >> 32);
-                        HandleFixedWrite(sock, nw, sock->write_buf_idx_);
-                        break;
-                    }
-                    case OpCode::NonFixedWriteFinish: {
-                        int nw = (int) (data >> 32);
-                        sock->RingNonFixedWriteCb(nw);
-                        break;
-                    }
-                    case OpCode::WaitingNonFixedWrite: {
-                        SubmitWaitingNonFixedWrite(sock);
-                        break;
-                    }
-                    default:
-                        LOG(FATAL) << "backlog has an unsupported op, " << (int) op;
-                        break;
-                }
-            }
-            waiting_cnt_.fetch_sub(cnt, std::memory_order_release);
-        }
-    }
-
-    bool SubmitBacklog(brpc::Socket *sock, uint64_t data) {
-        waiting_cnt_.fetch_add(1, std::memory_order_relaxed);
-        bool success = waiting_socks_.TryEnqueue(std::make_pair(sock, data));
-        if (!success) {
-            waiting_cnt_.fetch_sub(1, std::memory_order_relaxed);
-        }
-
-        return success;
-    }
+    bool SubmitBacklog(brpc::Socket *sock, uint64_t data);
 
     enum struct PollStatus : uint8_t { Active = 0, Sleep, ExtPoll, Closed };
 
@@ -900,6 +243,10 @@ private:
 
     inline static size_t buf_length = sysconf(_SC_PAGESIZE);
     inline static size_t buf_ring_size = 1024;
+
+    RingModule *ring_module_{};
+
+    friend class RingModule;
 };
 
 #endif

--- a/src/bthread/ring_module.cpp
+++ b/src/bthread/ring_module.cpp
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include "ring_module.h"
+#include "ring_listener.h"
+#include <atomic>
+
+#ifdef IO_URING_ENABLED
+void RingModule::ExtThdStart(int thd_id) {
+    listeners_.at(thd_id)->has_external_.store(true, std::memory_order_relaxed);
+}
+
+void RingModule::ExtThdEnd(int thd_id) { listeners_.at(thd_id)->ExtWakeup(); }
+
+void RingModule::Process(int thd_id) {
+    // LOG(INFO) << "Process thd_id: " << thd_id;
+    listeners_.at(thd_id)->ExtPoll();
+}
+
+bool RingModule::HasTask(int thd_id) const {
+    RingListener *listener = listeners_.at(thd_id);
+    return listener->HasTasks();
+}
+
+void RingModule::AddListener(int thd_id, RingListener *listener) {
+    // protected by TaskControl::_modify_group_mutex
+    // if (listeners_.size() < thd_id) {
+    //     listeners_.resize(thd_id);
+    // }
+    LOG(INFO) << "AddListener, thdid: " << thd_id << ", listener: " << listener;
+    listeners_[thd_id] = listener;
+}
+
+#endif

--- a/src/bthread/ring_module.cpp
+++ b/src/bthread/ring_module.cpp
@@ -30,7 +30,6 @@ void RingModule::ExtThdStart(int thd_id) {
 void RingModule::ExtThdEnd(int thd_id) { listeners_.at(thd_id)->ExtWakeup(); }
 
 void RingModule::Process(int thd_id) {
-    // LOG(INFO) << "Process thd_id: " << thd_id;
     listeners_.at(thd_id)->ExtPoll();
 }
 
@@ -41,10 +40,6 @@ bool RingModule::HasTask(int thd_id) const {
 
 void RingModule::AddListener(int thd_id, RingListener *listener) {
     // protected by TaskControl::_modify_group_mutex
-    // if (listeners_.size() < thd_id) {
-    //     listeners_.resize(thd_id);
-    // }
-    LOG(INFO) << "AddListener, thdid: " << thd_id << ", listener: " << listener;
     listeners_[thd_id] = listener;
 }
 

--- a/src/bthread/ring_module.h
+++ b/src/bthread/ring_module.h
@@ -17,13 +17,29 @@
  * under the License.
  */
 
-#include "brpc_module.h"
-#include "bthread/bthread.h"
+#pragma once
+#include "bthread/brpc_module.h"
+#include "bthread/types.h"
+#include <array>
+#include <thread>
 
-namespace eloq {
+#ifdef IO_URING_ENABLED
+class RingListener;
 
-bool EloqModule::NotifyWorker(int thd_id) {
-  return bthread_notify_worker(thd_id);
-}
+class RingModule : public eloq::EloqModule {
+public:
+    void ExtThdStart(int thd_id) override;
 
-}  // namespace bthread
+    void ExtThdEnd(int thd_id) override;
+
+    void Process(int thd_id) override;
+
+    bool HasTask(int thd_id) const override;
+
+    void AddListener(int thd_id, RingListener *listener);
+
+private:
+    std::array<RingListener *, BTHREAD_MAX_CONCURRENCY> listeners_{};
+};
+
+#endif

--- a/src/bthread/task_control.cpp
+++ b/src/bthread/task_control.cpp
@@ -40,6 +40,7 @@ DEFINE_int32(task_group_runqueue_capacity, 4096,
              "capacity of runqueue in each TaskGroup");
 DEFINE_int32(task_group_yield_before_idle, 0,
              "TaskGroup yields so many times before idle");
+DECLARE_bool(use_io_uring);
 
 namespace bthread {
 
@@ -326,6 +327,11 @@ int TaskControl::_add_group(TaskGroup* g) {
         _parking_lot_num++;
         _ngroup.store(ngroup + 1, butil::memory_order_release);
         CHECK(_parking_lot_num.load() == int(_ngroup.load()));
+        ring_module_.AddListener(ngroup, g->ring_listener_.get());
+        if (ngroup == 0 && FLAGS_use_io_uring) {
+            // The first group worker registers the RingModule.
+            register_module(&ring_module_);
+        }
     }
     mu.unlock();
     // See the comments in _destroy_group

--- a/src/bthread/task_control.h
+++ b/src/bthread/task_control.h
@@ -32,6 +32,7 @@
 #include "butil/resource_pool.h"                 // ResourcePool
 #include "bthread/work_stealing_queue.h"        // WorkStealingQueue
 #include "bthread/parking_lot.h"
+#include "bthread/ring_module.h"
 
 namespace bthread {
 
@@ -86,6 +87,12 @@ public:
     // Select task group.
     TaskGroup* select_group(int group_id);
 
+#ifdef IO_URING_ENABLED
+    RingModule* get_ring_module() {
+        return &ring_module_;
+    }
+#endif
+
 private:
     // Add/Remove a TaskGroup.
     // Returns 0 on success, -1 otherwise.
@@ -124,6 +131,9 @@ private:
     // one worker one parking lot for precise wakeup
     std::atomic<int> _parking_lot_num{0};
     ParkingLot _pl[PARKING_LOT_NUM];
+#ifdef IO_URING_ENABLED
+    RingModule ring_module_;
+#endif
 };
 
 inline bvar::LatencyRecorder& TaskControl::exposed_pending_time() {

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -209,11 +209,11 @@ bool TaskGroup::wait_task(bthread_t* tid) {
 #endif
                 NotifyRegisteredModules(WorkerStatus::Sleep);
 
-                LOG(INFO) << "group: " << group_id_ << " wait...";
-                auto start_ms = butil::cpuwide_time_ms();
+                // LOG(INFO) << "group: " << group_id_ << " wait...";
+                // auto start_ms = butil::cpuwide_time_ms();
                 Wait();
-                LOG(INFO) << "group: " << group_id_ << " wait finishes after: "
-                    << butil::cpuwide_time_ms() - start_ms << " ms";
+                // LOG(INFO) << "group: " << group_id_ << " wait finishes after: "
+                //     << butil::cpuwide_time_ms() - start_ms << " ms";
 
                 NotifyRegisteredModules(WorkerStatus::Working);
 

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -209,11 +209,7 @@ bool TaskGroup::wait_task(bthread_t* tid) {
 #endif
                 NotifyRegisteredModules(WorkerStatus::Sleep);
 
-                // LOG(INFO) << "group: " << group_id_ << " wait...";
-                // auto start_ms = butil::cpuwide_time_ms();
                 Wait();
-                // LOG(INFO) << "group: " << group_id_ << " wait finishes after: "
-                //     << butil::cpuwide_time_ms() - start_ms << " ms";
 
                 NotifyRegisteredModules(WorkerStatus::Working);
 
@@ -1287,7 +1283,6 @@ void TaskGroup::ProcessModulesTask() {
     }
     for (auto *module : registered_modules_) {
         if (module != nullptr) {
-            // LOG(INFO) << "group: " << group_id_ << " Process, module: " << module;
             module->Process(group_id_);
         }
     }
@@ -1311,7 +1306,6 @@ bool TaskGroup::CheckAndUpdateModules() {
         modules_cnt_ = std::count_if(registered_modules_.begin(), registered_modules_.end(), [](eloq::EloqModule* module) {
             return module != nullptr;
         });
-        LOG(INFO) << "group: " << group_id_ << " registered modules size: " << modules_cnt_;
         return true;
     }
     return false;

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -197,7 +197,7 @@ bool TaskGroup::wait_task(bthread_t* tid) {
         // keep polling for some time before waiting on parking lot
         if (FLAGS_worker_polling_time_us <= 0 ||
             butil::cpuwide_time_us() - poll_start_us > FLAGS_worker_polling_time_us) {
-            if (NoTasks()) {
+            if (!HasTasks()) {
                 if (update_ext_proc_) {
                     update_ext_proc_(-1);
                 }
@@ -210,8 +210,10 @@ bool TaskGroup::wait_task(bthread_t* tid) {
                 NotifyRegisteredModules(WorkerStatus::Sleep);
 
                 LOG(INFO) << "group: " << group_id_ << " wait...";
+                auto start_ms = butil::cpuwide_time_ms();
                 Wait();
-                LOG(INFO) << "group: " << group_id_ << " wait done";
+                LOG(INFO) << "group: " << group_id_ << " wait finishes after: "
+                    << butil::cpuwide_time_ms() - start_ms << " ms";
 
                 NotifyRegisteredModules(WorkerStatus::Working);
 
@@ -703,8 +705,8 @@ void TaskGroup::ending_sched(TaskGroup** pg) {
     const bool popped = g->_rq.steal(&next_tid);
 #endif
     if (!popped) {
-        // Yield proactively to run tx processor workload.
-        if (g->tx_processor_exec_ && g->_processed_tasks > 30) {
+        // Yield proactively to run modules workload.
+        if (g->modules_cnt_ > 0 && g->_processed_tasks > 30) {
             g->_processed_tasks = 0;
             next_tid = g->_main_tid;
         } else {
@@ -754,8 +756,8 @@ void TaskGroup::sched(TaskGroup** pg) {
     const bool popped = g->_rq.steal(&next_tid);
 #endif
     if (!popped) {
-        // Yield proactively to run tx processor workload.
-        if (g->tx_processor_exec_ && g->_processed_tasks > 30) {
+        // Yield proactively to run modules workload.
+        if (g->modules_cnt_ > 0 && g->_processed_tasks > 30) {
             g->_processed_tasks = 0;
             next_tid = g->_main_tid;
         } else {
@@ -1278,8 +1280,10 @@ bool TaskGroup::Wait(){
                 update_ext_proc_(-1);
             }
         }
+        // Check any new module registered before checking modules' tasks.
+        CheckAndUpdateModules();
+
         return HasTasks();
-        return !NoTasks();
     });
 #ifdef IO_URING_ENABLED
     signaled_by_ring_.store(false, std::memory_order_relaxed);
@@ -1299,17 +1303,7 @@ void TaskGroup::RunExtTxProcTask() {
 }
 
 void TaskGroup::ProcessModulesTask() {
-    int registered_modules_cnt = 0;
-    for (auto *module : registered_modules_) {
-        if (module != nullptr) {
-            registered_modules_cnt++;
-        } else {
-            break;
-        }
-    }
-    if (registered_modules_cnt < registered_module_cnt.load(std::memory_order_acquire)) {
-        LOG(INFO) << "group: " << group_id_ << " registered modules size: " << registered_modules_cnt;
-        registered_modules_ = registered_modules;
+    if (CheckAndUpdateModules()) {
         NotifyRegisteredModules(WorkerStatus::Working);
     }
     for (auto *module : registered_modules_) {
@@ -1324,16 +1318,26 @@ bool TaskGroup::HasTasks() {
     if (!_remote_rq.empty() || !_bound_rq.empty()) {
         return true;
     }
-    if (registered_modules_.size() < registered_module_cnt.load(std::memory_order_acquire)) {
+    bool has_task = std::any_of(registered_modules_.begin(), registered_modules_.end(),
+        [this](eloq::EloqModule* module) {
+            return module != nullptr && module->HasTask(group_id_);
+    });
+
+    return has_task;
+}
+
+bool TaskGroup::CheckAndUpdateModules() {
+    if (modules_cnt_ < registered_module_cnt.load(std::memory_order_acquire)) {
         registered_modules_ = registered_modules;
-    }
-    for (eloq::EloqModule *module : registered_modules_) {
-        if (module != nullptr && module->HasTask(group_id_)) {
-            return true;
-        }
+        modules_cnt_ = std::count_if(registered_modules_.begin(), registered_modules_.end(), [](auto* module) {
+            return module != nullptr;
+        });
+        LOG(INFO) << "group: " << group_id_ << " registered modules size: " << modules_cnt_;
+        return true;
     }
     return false;
 }
+
 
 void TaskGroup::NotifyRegisteredModules(WorkerStatus status) {
     for (eloq::EloqModule *module : registered_modules_) {

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -52,7 +52,7 @@ std::function<std::tuple<std::function<void()>,
 
 std::atomic<bool> tx_proc_functors_set{false};
 
-std::array<bthread::BrpcModule *, 10> registered_modules;
+std::array<eloq::EloqModule *, 10> registered_modules;
 std::atomic<int> registered_module_cnt;
 
 DEFINE_int32(steal_task_rnd, 100, "Steal task frequency in wait_task");
@@ -209,7 +209,9 @@ bool TaskGroup::wait_task(bthread_t* tid) {
 #endif
                 NotifyRegisteredModules(WorkerStatus::Sleep);
 
+                LOG(INFO) << "group: " << group_id_ << " wait...";
                 Wait();
+                LOG(INFO) << "group: " << group_id_ << " wait done";
 
                 NotifyRegisteredModules(WorkerStatus::Working);
 
@@ -1276,8 +1278,8 @@ bool TaskGroup::Wait(){
                 update_ext_proc_(-1);
             }
         }
-        return !NoTasks();
         return HasTasks();
+        return !NoTasks();
     });
 #ifdef IO_URING_ENABLED
     signaled_by_ring_.store(false, std::memory_order_relaxed);
@@ -1297,13 +1299,22 @@ void TaskGroup::RunExtTxProcTask() {
 }
 
 void TaskGroup::ProcessModulesTask() {
-    if (registered_modules_.size() < registered_module_cnt.load(std::memory_order_acquire)) {
+    int registered_modules_cnt = 0;
+    for (auto *module : registered_modules_) {
+        if (module != nullptr) {
+            registered_modules_cnt++;
+        } else {
+            break;
+        }
+    }
+    if (registered_modules_cnt < registered_module_cnt.load(std::memory_order_acquire)) {
+        LOG(INFO) << "group: " << group_id_ << " registered modules size: " << registered_modules_cnt;
         registered_modules_ = registered_modules;
-        bool sleep = false;
         NotifyRegisteredModules(WorkerStatus::Working);
     }
     for (auto *module : registered_modules_) {
         if (module != nullptr) {
+            // LOG(INFO) << "group: " << group_id_ << " Process, module: " << module;
             module->Process(group_id_);
         }
     }
@@ -1316,7 +1327,7 @@ bool TaskGroup::HasTasks() {
     if (registered_modules_.size() < registered_module_cnt.load(std::memory_order_acquire)) {
         registered_modules_ = registered_modules;
     }
-    for (bthread::BrpcModule *module : registered_modules_) {
+    for (eloq::EloqModule *module : registered_modules_) {
         if (module != nullptr && module->HasTask(group_id_)) {
             return true;
         }
@@ -1325,7 +1336,7 @@ bool TaskGroup::HasTasks() {
 }
 
 void TaskGroup::NotifyRegisteredModules(WorkerStatus status) {
-    for (bthread::BrpcModule *module : registered_modules_) {
+    for (eloq::EloqModule *module : registered_modules_) {
         if (module != nullptr) {
             if (status == WorkerStatus::Sleep) {
                 module->ExtThdEnd(group_id_);

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -37,6 +37,7 @@
 #include "bthread/timer_thread.h"
 #include "bthread/errno.h"
 #include "task_meta.h"
+#include "bthread/brpc_module.h"
 #ifdef IO_URING_ENABLED
 #include <liburing.h>
 #include "ring_write_buf_pool.h"
@@ -50,6 +51,9 @@ std::function<std::tuple<std::function<void()>,
         get_tx_proc_functors{nullptr};
 
 std::atomic<bool> tx_proc_functors_set{false};
+
+std::array<bthread::BrpcModule *, 10> registered_modules;
+std::atomic<int> registered_module_cnt;
 
 DEFINE_int32(steal_task_rnd, 100, "Steal task frequency in wait_task");
 DEFINE_bool(brpc_worker_as_ext_processor, false, "Work as external processor");
@@ -155,17 +159,11 @@ bool TaskGroup::wait_task(bthread_t* tid) {
             RunExtTxProcTask();
         }
 
+        ProcessModulesTask();
+
 #ifdef IO_URING_ENABLED
         if (FLAGS_use_io_uring && ring_listener_ != nullptr) {
             size_t ring_poll_cnt = ring_listener_->ExtPoll();
-
-            size_t cnt = inbound_queue_.TryDequeueBulk(inbound_batch_.begin(),
-                                                       inbound_batch_.size());
-            for (size_t idx = 0; idx < cnt; ++idx) {
-                InboundRingBuf &rbuf = inbound_batch_[idx];
-                brpc::Socket *sock = rbuf.sock_;
-                brpc::Socket::SocketResume(sock, rbuf, this);
-            }
         }
 #endif
 
@@ -209,7 +207,11 @@ bool TaskGroup::wait_task(bthread_t* tid) {
                     ring_listener_->ExtWakeup();
                 }
 #endif
+                NotifyRegisteredModules(WorkerStatus::Sleep);
+
                 Wait();
+
+                NotifyRegisteredModules(WorkerStatus::Working);
 
                 if (update_ext_proc_) {
                     update_ext_proc_(1);
@@ -287,9 +289,6 @@ TaskGroup::TaskGroup(TaskControl* c)
     , _remote_nsignaled(0)
 #ifndef NDEBUG
     , _sched_recursive_guard(0)
-#endif
-#ifdef IO_URING_ENABLED
-    , inbound_queue_(1024)
 #endif
 {
     _steal_seed = butil::fast_rand();
@@ -1278,6 +1277,7 @@ bool TaskGroup::Wait(){
             }
         }
         return !NoTasks();
+        return HasTasks();
     });
 #ifdef IO_URING_ENABLED
     signaled_by_ring_.store(false, std::memory_order_relaxed);
@@ -1293,6 +1293,46 @@ void TaskGroup::RunExtTxProcTask() {
     }
     if (tx_processor_exec_) {
         tx_processor_exec_();
+    }
+}
+
+void TaskGroup::ProcessModulesTask() {
+    if (registered_modules_.size() < registered_module_cnt.load(std::memory_order_acquire)) {
+        registered_modules_ = registered_modules;
+        bool sleep = false;
+        NotifyRegisteredModules(WorkerStatus::Working);
+    }
+    for (auto *module : registered_modules_) {
+        if (module != nullptr) {
+            module->Process(group_id_);
+        }
+    }
+}
+
+bool TaskGroup::HasTasks() {
+    if (!_remote_rq.empty() || !_bound_rq.empty()) {
+        return true;
+    }
+    if (registered_modules_.size() < registered_module_cnt.load(std::memory_order_acquire)) {
+        registered_modules_ = registered_modules;
+    }
+    for (bthread::BrpcModule *module : registered_modules_) {
+        if (module != nullptr && module->HasTask(group_id_)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void TaskGroup::NotifyRegisteredModules(WorkerStatus status) {
+    for (bthread::BrpcModule *module : registered_modules_) {
+        if (module != nullptr) {
+            if (status == WorkerStatus::Sleep) {
+                module->ExtThdEnd(group_id_);
+            } else {
+                module->ExtThdStart(group_id_);
+            }
+        }
     }
 }
 
@@ -1386,14 +1426,6 @@ int TaskGroup::RingFsync(int fd) {
 
 const char *TaskGroup::GetRingReadBuf(uint16_t buf_id) {
   return ring_listener_->GetReadBuf(buf_id);
-}
-
-bool TaskGroup::EnqueueInboundRingBuf(brpc::Socket *sock, int32_t bytes,
-                                      uint16_t bid, bool rearm) {
-  bool success =
-      inbound_queue_.TryEnqueue(InboundRingBuf(sock, bytes, bid, rearm));
-  _control->signal_group(group_id_);
-  return success;
 }
 
 void TaskGroup::RecycleRingReadBuf(uint16_t bid, int32_t bytes) {

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -1329,7 +1329,7 @@ bool TaskGroup::HasTasks() {
 bool TaskGroup::CheckAndUpdateModules() {
     if (modules_cnt_ < registered_module_cnt.load(std::memory_order_acquire)) {
         registered_modules_ = registered_modules;
-        modules_cnt_ = std::count_if(registered_modules_.begin(), registered_modules_.end(), [](auto* module) {
+        modules_cnt_ = std::count_if(registered_modules_.begin(), registered_modules_.end(), [](eloq::EloqModule* module) {
             return module != nullptr;
         });
         LOG(INFO) << "group: " << group_id_ << " registered modules size: " << modules_cnt_;

--- a/src/bthread/task_group.h
+++ b/src/bthread/task_group.h
@@ -34,8 +34,6 @@
 #include "bthread/parking_lot.h"
 
 #ifdef IO_URING_ENABLED
-#include "spsc_queue.h"
-#include "inbound_ring_buf.h"
 
 class RingWriteBufferPool;
 class RingListener;
@@ -227,7 +225,7 @@ public:
     std::function<bool(bool)> override_shard_heap_{nullptr};
     std::function<bool()> has_tx_processor_work_{nullptr};
 
-    std::array<bthread::BrpcModule *, 10> registered_modules_{};
+    std::array<eloq::EloqModule *, 10> registered_modules_{};
 
 #ifdef IO_URING_ENABLED
     bool RingListenerNotify();

--- a/src/bthread/task_group.h
+++ b/src/bthread/task_group.h
@@ -226,6 +226,7 @@ public:
     std::function<bool()> has_tx_processor_work_{nullptr};
 
     std::array<eloq::EloqModule *, 10> registered_modules_{};
+    int modules_cnt_{0};
 
 #ifdef IO_URING_ENABLED
     bool RingListenerNotify();
@@ -302,6 +303,8 @@ public:
     void ProcessModulesTask();
 
     bool HasTasks();
+
+    bool CheckAndUpdateModules();
 
     enum struct WorkerStatus
     {

--- a/src/bthread/task_group.h
+++ b/src/bthread/task_group.h
@@ -229,7 +229,6 @@ public:
     int modules_cnt_{0};
 
 #ifdef IO_URING_ENABLED
-    bool RingListenerNotify();
     int RegisterSocket(brpc::Socket *sock);
     void UnregisterSocket(int fd);
     void SocketRecv(brpc::Socket *sock);
@@ -294,8 +293,6 @@ public:
         return _control->steal_task(tid, &_steal_seed, _steal_offset);
     }
 
-    bool NoTasks();
-
     bool Wait();
 
     void RunExtTxProcTask();
@@ -352,7 +349,6 @@ public:
     std::condition_variable _cv;
 
 #ifdef IO_URING_ENABLED
-    std::atomic<bool> signaled_by_ring_{false};
     std::unique_ptr<RingListener> ring_listener_{nullptr};
 #endif
 };


### PR DESCRIPTION
Allow other codes to register a module into brpc worker. Workers will process modules' tasks and notify them when worker sleeps or wakes up.

Refactor RingListeners as a RingModule.

Related PR:
https://github.com/monographdb/tx_service/pull/1511