### PR TITLE
StreamWrite conjestion control use spin lock for bthread instead of blocking and sched.

### DIFF
--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -804,10 +804,6 @@ void TaskGroup::sched_to(TaskGroup** pg, TaskMeta* next_meta) {
     ++ g->_nswitch;
     // Switch to the task
     if (__builtin_expect(next_meta != cur_meta, 1)) {
-        bool need_restore_heap = false;
-        if (g->override_shard_heap_) {
-            need_restore_heap = g->override_shard_heap_(true);
-        }
         g->_cur_meta = next_meta;
         // Switch tls_bls
         cur_meta->local_storage = tls_bls;
@@ -836,12 +832,6 @@ void TaskGroup::sched_to(TaskGroup** pg, TaskMeta* next_meta) {
 #endif
         }
         // else because of ending_sched(including pthread_task->pthread_task)
-        if (need_restore_heap) {
-            // Only the task that occupies tx shard needs to restore heap, and
-            // there's only one task per task group that can gain access to the shard
-            // at a time.
-            g->override_shard_heap_(false);
-        }
     } else {
         LOG(FATAL) << "bthread=" << g->current_tid() << " sched_to itself!";
     }


### PR DESCRIPTION
So that we don't need functor `override_shard_heap` when bthread is externally forwarding the txm and `doing StreamWrite`.