### PR TITLE
merge redis protocol fixed write into StartWrite; fix multiple on-flying fixed write bug

### DIFF
--- a/src/brpc/policy/redis_protocol.cpp
+++ b/src/brpc/policy/redis_protocol.cpp
@@ -210,11 +210,12 @@ ParseResult ParseRedisMessage(butil::IOBuf* source, Socket* socket,
             uint32_t ring_buf_size = appender.ring_buffer_size();
             if (ring_buf_size > 0) {
                 CHECK(sendbuf.empty());
-                socket->SetFixedWriteLen(ring_buf_size);
-                int ret = cur_group->SocketFixedWrite(socket, ring_buf_idx);
-                if (ret != 0) {
-                    // If the fixed buffer write is not submitted,
-                    // falls back to the old socket write.
+                Socket::WriteOptions wopt;
+                wopt.ignore_eovercrowded = true;
+                wopt.write_through_ring = true;
+                if (socket->Write(ring_buf, ring_buf_idx, ring_buf_size, &wopt) != 0) {
+                    LOG(WARNING) << "Fail to send redis reply through iouring registered buffer";
+                    // If the fixed buffer write is not submitted, falls back to the old socket write.
                     sendbuf.append(ring_buf, ring_buf_size);
                     cur_group->RecycleRingWriteBuf(ring_buf_idx);
                 } else {
@@ -223,10 +224,6 @@ ParseResult ParseRedisMessage(butil::IOBuf* source, Socket* socket,
                 }
             } else if (ring_buf != nullptr) {
                 cur_group->RecycleRingWriteBuf(ring_buf_idx);
-            }
-
-            if (ring_buf_size == 0) {
-                DLOG(INFO) << "Redis socket write not using fixed buffer.";
             }
         }
 #endif

--- a/src/brpc/policy/redis_protocol.cpp
+++ b/src/brpc/policy/redis_protocol.cpp
@@ -177,7 +177,6 @@ ParseResult ParseRedisMessage(butil::IOBuf* source, Socket* socket,
             std::tie(ring_buf, ring_buf_idx) = cur_group->GetRingWriteBuf();
             appender.set_ring_buffer(ring_buf, RingWriteBufferPool::buf_length);
         }
-        // LOG(INFO) << "use ring_buf idx: " << ring_buf_idx;
 #endif
 
         err = ctx->parser.Consume(*source, &current_args, &ctx->arena);

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -1921,7 +1921,6 @@ int Socket::StartWrite(WriteRequest* req, const WriteOptions& opt) {
                 io_uring_write_req_ = req;
                 req->socket = this;
                 if (req->ring_buf != nullptr) {
-                    write_len_ = req->ring_buf_size;
                     // LOG(INFO) << "socket: " << *this << "submit fixed write, buf idx: " << req->ring_buf_idx
                     //     << ", data: " << std::string_view(req->ring_buf, std::min(20, int(req->ring_buf_size))) << ", size: " << req->ring_buf_size;
                     int ret = g->SocketFixedWrite(this, req->ring_buf_idx, req->ring_buf_size);
@@ -3299,8 +3298,6 @@ void Socket::ProcessInbound() {
     SocketProcess(this);
   }
 }
-
-void Socket::SetFixedWriteLen(uint32_t write_len) { write_len_ = write_len; }
 
 int Socket::WaitForNonFixedWrite() {
     std::unique_lock lk(keep_write_mutex_);

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -3312,6 +3312,7 @@ void Socket::RingNonFixedWriteCb(int nw) {
     WriteRequest *req = io_uring_write_req_;
     CHECK(req->socket == this);
     if (nw > 0) {
+        // ring_buf is not null if this is a fixed write of the socket.
         if (req->ring_buf_data.ring_buf != nullptr) {
             // LOG(INFO) << "socket: " << *this << "Handle fixed write res, nw: " << nw
             //     << ", ring_bufsize: " << req->ring_buf_data.ring_buf_size

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -559,8 +559,6 @@ void Socket::ReturnSuccessfulWriteRequest(Socket::WriteRequest* p) {
     const bthread_id_t id_wait = p->id_wait;
 #ifdef IO_URING_ENABLED
     if (FLAGS_use_io_uring && p->ring_buf_data.ring_buf_idx != -1) {
-        // CHECK(socket != nullptr && socket->bound_g_ != nullptr);
-        // socket->bound_g_->RecycleRingWriteBuf(p->ring_buf_data.ring_buf_idx);
         bound_g_->RecycleRingWriteBuf(p->ring_buf_data.ring_buf_idx);
         p->ring_buf_data.reset();
     }

--- a/src/brpc/socket.cpp
+++ b/src/brpc/socket.cpp
@@ -1969,7 +1969,6 @@ int Socket::StartWrite(WriteRequest* req, const WriteOptions& opt) {
                     }
                     LOG(WARNING) << "Socket: " << *this << " FixedWrite failed, will KeepWrite";
                 } else {
-                    io_uring_write_req_ = req;
                     req->data.prepare_iovecs(&iovecs_);
                     req->socket = this;
                     // If this write is from Stream's DoWrite, wait and return the result.
@@ -2175,7 +2174,7 @@ void cut_data_into_iovecs(std::vector<struct iovec> *iovecs,
                 iovecs->emplace_back();
                 iovec &iov = iovecs->back();
                 // LOG(INFO) << "buf data: " << std::string_view(rb->ring_buf, std::min(50, int(rb->ring_buf_size)));
-                iov.iov_base = const_cast<char*>(rb->ring_buf);
+                iov.iov_base = rb->ring_buf;
                 iov.iov_len = rb->ring_buf_size;
             }
         }

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -351,6 +351,12 @@ public:
             {}
 #endif
     };
+
+#ifdef IO_URING_ENABLED
+    int Write(const char *ring_buf, uint16_t ring_buf_idx, uint32_t ring_buf_size,
+        const WriteOptions* options = NULL);
+#endif
+
     int Write(butil::IOBuf *msg, const WriteOptions* options = NULL);
 
     // Write an user-defined message. `msg' is released when Write() is

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -637,7 +637,6 @@ public:
 #ifdef IO_URING_ENABLED
     void RingNonFixedWriteCb(int nw);
     void ProcessInbound();
-    void SetFixedWriteLen(uint32_t write_len);
     int WaitForNonFixedWrite();
     void NotifyWaitingNonFixedWrite(int nw);
     int CopyDataRead();
@@ -1003,8 +1002,6 @@ private:
     // of the socket.
     int reg_fd_{-1};
     uint16_t recv_num_{0};
-    uint16_t write_buf_idx_{UINT16_MAX};
-    uint32_t write_len_{0};
 
 #ifdef IO_URING_ENABLED
     friend class ::RingListener;

--- a/src/brpc/socket.h
+++ b/src/brpc/socket.h
@@ -353,7 +353,7 @@ public:
     };
 
 #ifdef IO_URING_ENABLED
-    int Write(const char *ring_buf, uint16_t ring_buf_idx, uint32_t ring_buf_size,
+    int Write(char *ring_buf, uint16_t ring_buf_idx, uint32_t ring_buf_size,
         const WriteOptions* options = NULL);
 #endif
 

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -446,10 +446,8 @@ void RingListener::RecycleWriteBuf(uint16_t buf_idx) {
     } else {
         // LOG(INFO) << "Not same group, cur group: " << cur_group->group_id_
         //     << ", buf group: " << task_group_->group_id_ << " push into write_bufs: " << buf_idx;
-        write_bufs_.enqueue(buf_idx);
-        // std::unique_lock<std::mutex> lk(recycle_buf_mutex_);
-        // recycle_bufs_.emplace_back(buf_idx);
         recycle_buf_cnt_.fetch_add(1, std::memory_order_relaxed);
+        write_bufs_.enqueue(buf_idx);
     }
 }
 

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -444,8 +444,8 @@ void RingListener::RecycleWriteBuf(uint16_t buf_idx) {
     if (task_group_ == cur_group) {
         write_buf_pool_->Recycle(buf_idx);
     } else {
-        LOG(INFO) << "Not same group, cur group: " << cur_group->group_id_
-            << ", buf group: " << task_group_->group_id_ << " push into write_bufs: " << buf_idx;
+        // LOG(INFO) << "Not same group, cur group: " << cur_group->group_id_
+        //     << ", buf group: " << task_group_->group_id_ << " push into write_bufs: " << buf_idx;
         write_bufs_.enqueue(buf_idx);
         // std::unique_lock<std::mutex> lk(recycle_buf_mutex_);
         // recycle_bufs_.emplace_back(buf_idx);

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -354,7 +354,7 @@ size_t RingListener::ExtPoll() {
         has_external_.store(true, std::memory_order_release);
     }
 
-    RecyclePendingBufs();
+    RecycleReturnedWriteBufs();
 
     // has_external_ should be updated before poll_status_ is checked.
     std::atomic_thread_fence(std::memory_order_release);
@@ -658,7 +658,7 @@ bool RingListener::SubmitBacklog(brpc::Socket *sock, uint64_t data) {
     return success;
 }
 
-void RingListener::RecyclePendingBufs() {
+void RingListener::RecycleReturnedWriteBufs() {
     while (recycle_buf_cnt_.load(std::memory_order_relaxed) > 0) {
         uint16_t buf_idxes[100];
         int n = write_bufs_.try_dequeue_bulk(buf_idxes, 100);

--- a/src/bthread/ring_listener.cpp
+++ b/src/bthread/ring_listener.cpp
@@ -184,7 +184,6 @@ int RingListener::SubmitFixedWrite(brpc::Socket *sock, uint16_t ring_buf_idx, ui
     //     << ", socket: " << *sock;
 
     const char *write_buf = write_buf_pool_->GetBuf(ring_buf_idx);
-    sock->write_buf_idx_ = ring_buf_idx;
 
     // LOG(INFO) << "io_uring_prep_write_fixed, len: " << ring_buf_size << ", buf_idx: " << ring_buf_idx;
     io_uring_prep_write_fixed(sqe, sfd, write_buf, ring_buf_size, 0, ring_buf_idx);

--- a/src/bthread/ring_listener.h
+++ b/src/bthread/ring_listener.h
@@ -144,7 +144,7 @@ private:
         Recv = 0,
         CancelRecv,
         RegisterFile,
-        // TODO(zkl): merge FixedWrite and NonFixedWrite
+        // TODO(zkl): Remove (Non)FixedWrite, merge into Write, WriteFinish
         FixedWrite,
         FixedWriteFinish,
         NonFixedWrite,
@@ -206,8 +206,6 @@ private:
 
     void HandleRecv(brpc::Socket *sock, io_uring_cqe *cqe);
 
-    // void HandleFixedWrite(brpc::Socket *sock, int nw, uint16_t write_buf_idx);
-
     void HandleBacklog();
 
     bool SubmitBacklog(brpc::Socket *sock, uint64_t data);
@@ -245,9 +243,7 @@ private:
     std::vector<uint16_t> free_reg_fd_idx_;
 
     std::unique_ptr<RingWriteBufferPool> write_buf_pool_;
-    // std::mutex recycle_buf_mutex_;
     moodycamel::ConcurrentQueue<uint16_t> write_bufs_;
-    // std::vector<uint16_t> recycle_bufs_;
     std::atomic<int64_t> recycle_buf_cnt_{0};
 
     inline static size_t buf_length = sysconf(_SC_PAGESIZE);

--- a/src/bthread/ring_listener.h
+++ b/src/bthread/ring_listener.h
@@ -87,7 +87,7 @@ public:
 
     int SubmitRecv(brpc::Socket *sock);
 
-    int SubmitFixedWrite(brpc::Socket *sock, uint16_t ring_buf_idx);
+    int SubmitFixedWrite(brpc::Socket *sock, uint16_t ring_buf_idx, uint32_t ring_buf_size);
 
     int SubmitNonFixedWrite(brpc::Socket *sock);
 
@@ -142,6 +142,7 @@ private:
         Recv = 0,
         CancelRecv,
         RegisterFile,
+        // TODO(zkl): merge FixedWrite and NonFixedWrite
         FixedWrite,
         FixedWriteFinish,
         NonFixedWrite,
@@ -203,7 +204,7 @@ private:
 
     void HandleRecv(brpc::Socket *sock, io_uring_cqe *cqe);
 
-    void HandleFixedWrite(brpc::Socket *sock, int nw, uint16_t write_buf_idx);
+    // void HandleFixedWrite(brpc::Socket *sock, int nw, uint16_t write_buf_idx);
 
     void HandleBacklog();
 

--- a/src/bthread/ring_listener.h
+++ b/src/bthread/ring_listener.h
@@ -210,7 +210,7 @@ private:
 
     bool SubmitBacklog(brpc::Socket *sock, uint64_t data);
 
-    void RecyclePendingBufs();
+    void RecycleReturnedWriteBufs();
 
     enum struct PollStatus : uint8_t { Active = 0, Sleep, ExtPoll, Closed };
 

--- a/src/bthread/ring_module.cpp
+++ b/src/bthread/ring_module.cpp
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-#pragma once
 #include "ring_module.h"
 #include "ring_listener.h"
 #include <atomic>

--- a/src/bthread/ring_write_buf_pool.h
+++ b/src/bthread/ring_write_buf_pool.h
@@ -76,7 +76,10 @@ public:
     return mem_bulk_ + (buf_idx * buf_length);
   }
 
-  void Recycle(uint16_t buf_idx) { buf_pool_.emplace_back(buf_idx); }
+  void Recycle(uint16_t buf_idx) {
+    // LOG(INFO) << "recycle buf idx: " << buf_idx;
+    buf_pool_.emplace_back(buf_idx);
+  }
 
   inline static size_t buf_length = sysconf(_SC_PAGESIZE);
 

--- a/src/bthread/ring_write_buf_pool.h
+++ b/src/bthread/ring_write_buf_pool.h
@@ -77,7 +77,6 @@ public:
   }
 
   void Recycle(uint16_t buf_idx) {
-    // LOG(INFO) << "recycle buf idx: " << buf_idx;
     buf_pool_.emplace_back(buf_idx);
   }
 

--- a/src/bthread/task_group.cpp
+++ b/src/bthread/task_group.cpp
@@ -1354,7 +1354,7 @@ void TaskGroup::SocketRecv(brpc::Socket *sock) {
   ring_listener_->SubmitRecv(sock);
 }
 
-int TaskGroup::SocketFixedWrite(brpc::Socket *sock, uint16_t ring_buf_idx) {
+int TaskGroup::SocketFixedWrite(brpc::Socket *sock, uint16_t ring_buf_idx, uint32_t ring_buf_size) {
   // ReAddress() increments references of the socket (same as
   // KeepWrite in background) so that the socket is still
   // available when the async IO finishes and the write request
@@ -1363,7 +1363,7 @@ int TaskGroup::SocketFixedWrite(brpc::Socket *sock, uint16_t ring_buf_idx) {
   brpc::SocketUniquePtr ptr_for_async_write;
   sock->ReAddress(&ptr_for_async_write);
 
-  int ret = ring_listener_->SubmitFixedWrite(sock, ring_buf_idx);
+  int ret = ring_listener_->SubmitFixedWrite(sock, ring_buf_idx, ring_buf_size);
   if (ret == 0) {
     (void)ptr_for_async_write.release();
   }

--- a/src/bthread/task_group.h
+++ b/src/bthread/task_group.h
@@ -232,7 +232,7 @@ public:
     int RegisterSocket(brpc::Socket *sock);
     void UnregisterSocket(int fd);
     void SocketRecv(brpc::Socket *sock);
-    int SocketFixedWrite(brpc::Socket *sock, uint16_t ring_buf_idx);
+    int SocketFixedWrite(brpc::Socket *sock, uint16_t ring_buf_idx, uint32_t ring_buf_size);
     int SocketNonFixedWrite(brpc::Socket *sock);
     int SocketWaitingNonFixedWrite(brpc::Socket *sock);
     int RingFsync(int fd);

--- a/src/butil/iobuf.cpp
+++ b/src/butil/iobuf.cpp
@@ -1002,6 +1002,17 @@ void IOBuf::cut_multiple_into_iovecs(std::vector<struct iovec> *iovecs,
     }
 }
 
+void IOBuf::cut_into_iovecs(std::vector<struct iovec> *iovecs) {
+    const size_t nref = _ref_num();
+    for (size_t j = 0; j < nref && iovecs->size() < IOV_MAX; ++j) {
+        iovecs->emplace_back();
+        iovec &iov = iovecs->back();
+        IOBuf::BlockRef const& r = _ref_at(j);
+        iov.iov_base = r.block->data + r.offset;
+        iov.iov_len = r.length;
+    }
+}
+
 ssize_t IOBuf::cut_into_writer(IWriter* writer, size_t size_hint) {
     if (empty()) {
         return 0;

--- a/src/butil/iobuf.h
+++ b/src/butil/iobuf.h
@@ -179,6 +179,8 @@ public:
     static void cut_multiple_into_iovecs(std::vector<struct iovec> *iovecs,
         IOBuf* const* pieces, size_t count);
 
+    void cut_into_iovecs(std::vector<struct iovec> *iovecs);
+
     // Cut into SSL channel `ssl'. Returns what `SSL_write' returns
     // and the ssl error code will be filled into `ssl_error'
     ssize_t cut_into_SSL_channel(struct ssl_st* ssl, int* ssl_error);


### PR DESCRIPTION
* Merge io_uring registered buffer (fixed write) handling into StartWrite.

* Add `RegisteredRingBuffer ring_buf_data` to WriteRequest, alongside IOBuf.  
  StartWrite and KeepWrite now handle ring_buf_data.  
  Registered buffers are recycled in ReturnSuccessfulWriteRequests upon success and ReturnFailedWriteRequest upon failure.

* Support cross-task-group recycling of write buffers.

* Fix the bug that write buf is not recycled when Redis message parsing fails.