### PR TITLE
Fix fork sampler.

### DIFF
--- a/src/bvar/detail/sampler.cpp
+++ b/src/bvar/detail/sampler.cpp
@@ -96,7 +96,7 @@ private:
             _created = true;
             if (!registered_atfork) {
                 registered_atfork = true;
-                pthread_atfork(NULL, NULL, child_callback_atfork);
+                // pthread_atfork(NULL, NULL, child_callback_atfork);
             }
         }
     }

--- a/src/bvar/detail/sampler.cpp
+++ b/src/bvar/detail/sampler.cpp
@@ -26,8 +26,6 @@
 #include "bvar/passive_status.h"
 #include "bvar/window.h"
 
-DEFINE_bool(bvar_enable_sampling, true, "is enable bvar sampling");
-
 namespace bvar {
 namespace detail {
 
@@ -201,6 +199,8 @@ void SamplerCollector::run() {
 Sampler::Sampler() : _used(true) {}
 
 Sampler::~Sampler() {}
+
+DEFINE_bool(bvar_enable_sampling, true, "is enable bvar sampling");
 
 void Sampler::schedule() {
     // since the SamplerCollector is initialized before the program starts


### PR DESCRIPTION
Disable `pthread_atfork` which calls pthread_create and conflicts with ASAN in forked process.
```
Attaching to process 641950
[New LWP 641951]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
__sanitizer::internal_sched_yield () at ../../../../src/libsanitizer/sanitizer_common/sanitizer_syscall_linux_x86_64.inc:19
19      ../../../../src/libsanitizer/sanitizer_common/sanitizer_syscall_linux_x86_64.inc: No such file or directory.
(gdb) bt
#0  __sanitizer::internal_sched_yield () at ../../../../src/libsanitizer/sanitizer_common/sanitizer_syscall_linux_x86_64.inc:19
#1  0x00007ffff7458775 in __interceptor_pthread_create (thread=0x60f000002de0, attr=<optimized out>, start_routine=0x7fffe8be4970 <bvar::detail::SamplerCollector::sampling_thread(void*)>, arg=0x60f000002d40)
    at ../../../../src/libsanitizer/asan/asan_interceptors.cpp:246
#2  0x00007fffe8be40f8 in bvar::detail::SamplerCollector::create_sampling_thread (this=<optimized out>) at /home/kevin/workspace/brpc/src/bvar/detail/sampler.cpp:92
#3  bvar::detail::SamplerCollector::after_forked_as_child (this=<optimized out>) at /home/kevin/workspace/brpc/src/bvar/detail/sampler.cpp:106
#4  bvar::detail::SamplerCollector::child_callback_atfork () at /home/kevin/workspace/brpc/src/bvar/detail/sampler.cpp:88
#5  0x00007ffff66eafc1 in __run_fork_handlers (who=who@entry=atfork_run_child, do_locking=do_locking@entry=true) at ./posix/register-atfork.c:130
#6  0x00007ffff66ea8d3 in __libc_fork () at ./posix/fork.c:108
#7  0x00007fffecc68d44 in txservice::Sharder::Init (
    this=0x7fffee97e380 <txservice::Sharder::Instance(unsigned int, std::unordered_map<unsigned int, std::vector<txservice::NodeConfig, std::allocator<txservice::NodeConfig> >, std::hash<unsigned int>, std::equal_to<unsigned int>, std::allocator<std::pair<unsigned int const, std::vector<txservice::NodeConfig, std::allocator<txservice::NodeConfig> > > > > const*, unsigned long, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const*, std::vector<unsigned short, std::allocator<unsigned short> > const*, txservice::LocalCcShards*, std::unique_ptr<txservice::TxLog, std::default_delete<txservice::TxLog> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const*)::instance_>, node_id=0, ng_id=0, ng_configs=0x7fffffff5350, config_version=2, txlog_ips=0x7fffffff5200, txlog_ports=0x7fffffff5240, hm_ip=0x7fffffff57f0, hm_port=0x7fffffff4d10, hm_bin_path=0x7fffffff5830,
    local_shards=0x61e000141080, log_agent=std::unique_ptr<txservice::TxLog> = {...}, local_path="local:///home/kevin/workspace/mariadb/cmake-build-debug-local-cluster/mysql-test/var/mysqld.1/data",
    rep_group_cnt=3, enable_brpc_builtin_services=true, fork_host_manager=true) at /home/kevin/workspace/mariadb/storage/eloq/tx_service/src/sharder.cpp:334
#8  0x00007fffec5a36de in txservice::TxService::Start (this=0x61e000141080, node_id=0, ng_id=0, ng_configs=0x7fffffff5350, cluster_config_version=2, txlog_ips=0x7fffffff5200, txlog_ports=0x7fffffff5240,
    hm_ip=0x7fffffff57f0, hm_port=0x7fffffff4d10, hm_bin_path=0x7fffffff5830, conf=std::map with 12 elements = {...}, log_agent=std::unique_ptr<txservice::TxLog> = {...},
    local_path="local:///home/kevin/workspace/mariadb/cmake-build-debug-local-cluster/mysql-test/var/mysqld.1/data", enable_brpc_builtin_services=true, fork_host_manager=true)
    at /home/kevin/workspace/mariadb/storage/eloq/tx_service/include/tx_service.h:1283
#9  0x00007fffec5111dc in eloq_init_func (p=0x61600000f408) at /home/kevin/workspace/mariadb/storage/eloq/ha_eloq.cc:2688
#10 0x0000555557979c77 in ha_initialize_handlerton (plugin=0x6210000365a8) at /home/kevin/workspace/mariadb/sql/handler.cc:664
#11 0x00005555570cf026 in plugin_initialize (tmp_root=0x7fffffff8230, plugin=0x6210000365a8, argc=0x55555b5597c0 <remaining_argc>, argv=0x61d000002968, options_only=false)
    at /home/kevin/workspace/mariadb/sql/sql_plugin.cc:1466
#12 0x00005555570d101a in plugin_init (argc=0x55555b5597c0 <remaining_argc>, argv=0x61d000002968, flags=0) at /home/kevin/workspace/mariadb/sql/sql_plugin.cc:1759
#13 0x0000555556d5fe57 in init_server_components () at /home/kevin/workspace/mariadb/sql/mysqld.cc:5134
#14 0x0000555556d620b2 in mysqld_main (argc=164, argv=0x61d000002968) at /home/kevin/workspace/mariadb/sql/mysqld.cc:5751
#15 0x0000555556d46369 in main (argc=6, argv=0x7fffffffaa68) at /home/kevin/workspace/mariadb/sql/main.cc:42
```