### PR TITLE
increase RLIMIT_MEMLOCK and decrease buffer pool size when io_uring_register_buffers returns ENOMEM

### DIFF
--- a/src/bthread/ring_write_buf_pool.h
+++ b/src/bthread/ring_write_buf_pool.h
@@ -26,64 +26,104 @@
 #include <butil/logging.h>
 #include <liburing.h>
 #include <vector>
+#include <sys/resource.h>
 
 class RingWriteBufferPool {
 public:
-  RingWriteBufferPool(size_t pool_size, io_uring *ring) {
-    mem_bulk_ = (char *)std::aligned_alloc(buf_length, buf_length * pool_size);
+    RingWriteBufferPool(size_t pool_size, io_uring *ring) {
+        mem_bulk_ = (char *) std::aligned_alloc(buf_length, buf_length * pool_size);
 
-    std::vector<iovec> register_buf;
-    register_buf.resize(pool_size);
-    buf_pool_.resize(pool_size);
+        std::vector<iovec> register_buf;
+        register_buf.resize(pool_size);
+        buf_pool_.resize(pool_size);
 
-    for (size_t idx = 0; idx < pool_size; ++idx) {
-      buf_pool_[idx] = idx;
-      register_buf[idx].iov_base = mem_bulk_ + (idx * buf_length);
-      register_buf[idx].iov_len = buf_length;
-    }
+        for (size_t idx = 0; idx < pool_size; ++idx) {
+            buf_pool_[idx] = idx;
+            register_buf[idx].iov_base = mem_bulk_ + (idx * buf_length);
+            register_buf[idx].iov_len = buf_length;
+        }
 
-    int ret = io_uring_register_buffers(ring, register_buf.data(),
-                                        register_buf.size());
-    if (ret != 0) {
-      LOG(WARNING) << "Failed to register IO uring fixed buffers. errno: "
-                   << ret;
-      free(mem_bulk_);
-      mem_bulk_ = nullptr;
-      buf_pool_.clear();
-    } else {
-      LOG(INFO) << "IO uring fixed buffers registered, buffer count: "
+        int ret = io_uring_register_buffers(ring, register_buf.data(),
+                                            register_buf.size());
+        if (ret < 0 && -ret == ENOMEM) {
+            LOG(ERROR) << "Failed to register IO uring fixed buffers: ENOMEM,"
+                    " trying to increase the RLIMIT_MEMLOCK limit";
+            rlimit rl;
+            if (getrlimit(RLIMIT_MEMLOCK, &rl) == -1) {
+                perror("getrlimit");
+                LOG(ERROR) << "getrlimit fails";
+            } else {
+                int32_t rlim_cur = rl.rlim_cur;
+                rl.rlim_cur = 128 * 1024 * 1024;
+                if (rl.rlim_cur > rl.rlim_max) {
+                    rl.rlim_cur = rl.rlim_max;
+                }
+                if (rl.rlim_cur > rlim_cur) {
+                    LOG(INFO) << "Increase rlim_cur from: " << rlim_cur << " bytes, to: "
+                        << rl.rlim_cur << " bytes, rlim_max: " << rl.rlim_max;
+
+                    if (setrlimit(RLIMIT_MEMLOCK, &rl) == -1) {
+                        perror("setrlimit");
+                        LOG(ERROR) << "setrlimit fails";
+                    } else {
+                        ret = io_uring_register_buffers(ring, register_buf.data(),
+                                                        register_buf.size());
+                    }
+                }
+            }
+        }
+        while (ret < 0 && -ret == ENOMEM && pool_size >= 128) {
+            pool_size /= 2;
+            LOG(ERROR) << "Failed to register IO uring fixed buffers: ENOMEM,"
+                    " trying to decrease the pool size to: " << pool_size;
+            register_buf.resize(pool_size);
+            buf_pool_.resize(pool_size);
+            ret = io_uring_register_buffers(ring, register_buf.data(),
+                                            register_buf.size());
+        }
+        if (ret < 0) {
+            int err = -ret;
+
+            LOG(ERROR) << "Failed to register IO uring fixed buffers. errno: "
+                    << err << " (" << strerror(err) << ")";
+
+            free(mem_bulk_);
+            mem_bulk_ = nullptr;
+            buf_pool_.clear();
+        } else {
+            LOG(INFO) << "IO uring fixed buffers registered, buffer count: "
                 << pool_size;
+        }
     }
-  }
 
-  ~RingWriteBufferPool() {
-    if (mem_bulk_ != nullptr) {
-      free(mem_bulk_);
+    ~RingWriteBufferPool() {
+        if (mem_bulk_ != nullptr) {
+            free(mem_bulk_);
+        }
     }
-  }
 
-  std::pair<char *, uint16_t> Get() {
-    if (buf_pool_.empty()) {
-      return {nullptr, UINT16_MAX};
-    } else {
-      uint16_t buf_idx = buf_pool_.back();
-      buf_pool_.pop_back();
-      return {mem_bulk_ + (buf_idx * buf_length), buf_idx};
+    std::pair<char *, uint16_t> Get() {
+        if (buf_pool_.empty()) {
+            return {nullptr, UINT16_MAX};
+        } else {
+            uint16_t buf_idx = buf_pool_.back();
+            buf_pool_.pop_back();
+            return {mem_bulk_ + (buf_idx * buf_length), buf_idx};
+        }
     }
-  }
 
-  const char *GetBuf(uint16_t buf_idx) const {
-    return mem_bulk_ + (buf_idx * buf_length);
-  }
+    const char *GetBuf(uint16_t buf_idx) const {
+        return mem_bulk_ + (buf_idx * buf_length);
+    }
 
-  void Recycle(uint16_t buf_idx) {
-    buf_pool_.emplace_back(buf_idx);
-  }
+    void Recycle(uint16_t buf_idx) {
+        buf_pool_.emplace_back(buf_idx);
+    }
 
-  inline static size_t buf_length = sysconf(_SC_PAGESIZE);
+    inline static size_t buf_length = sysconf(_SC_PAGESIZE);
 
 private:
-  char *mem_bulk_{nullptr};
-  std::vector<uint16_t> buf_pool_;
+    char *mem_bulk_{nullptr};
+    std::vector<uint16_t> buf_pool_;
 };
 #endif

--- a/src/butil/iobuf_inl.h
+++ b/src/butil/iobuf_inl.h
@@ -344,6 +344,8 @@ inline int IOBufAppender::push_back(char c) {
             // content of the ring buffer to the old stream.
             int ret = append_to_stream(ring_buf_, ring_buf_size_);
             ring_buf_size_ = 0;
+            // The ring_buf_ will be recycled on the outside in `ParseRedisMessage`
+            // since ring_buffer_size is 0.
             ring_buf_ = nullptr;
             if (ret < 0) {
                 return ret;


### PR DESCRIPTION
Fix the bug when write_buffer_pool->Get() returns null and UINT16_MAX the buf index is still recycled.