### PR TITLE
add inline redis protocol support

### DIFF
--- a/src/brpc/redis_command.cpp
+++ b/src/brpc/redis_command.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <cctype>
 
 #include "butil/logging.h"
 #include "brpc/log.h"
@@ -383,6 +384,9 @@ ParseError RedisCommandParser::Consume(butil::IOBuf& buf,
     }
     // '*' stands for array "*<size>\r\n<sub-reply1><sub-reply2>..."
     if (!_parsing_array && *pfc != '*') {
+        if (!std::isalpha(static_cast<unsigned char>(*pfc))) {
+            return PARSE_ERROR_TRY_OTHERS;
+        }
         const size_t buf_size = buf.size();
         const auto copy_str = static_cast<char *>(arena->allocate(buf_size));
         buf.copy_to(copy_str, buf_size);


### PR DESCRIPTION
Add inline redis protocol support. This can make eloqkv be able to be tested by more benchmark tools, such as `dfly_bench` and `redis_benchmark`.

With inline protocol, we can send requests to eloqkv by huma readable texts.
![8d3716f8b8831346d88a674307bbe7c3](https://github.com/user-attachments/assets/3d45d12c-f6ec-4db1-88ad-04b2e80d9129)
